### PR TITLE
🐛 Fixed vscode incompatibilities with prettier v3

### DIFF
--- a/.changeset/thin-knives-nail.md
+++ b/.changeset/thin-knives-nail.md
@@ -1,0 +1,5 @@
+---
+"@2digits/prettier-config": major
+---
+
+Fixed prettier v3 to support vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prettier.prettierPath": "node_modules/prettier/index.cjs"
+}

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -1,7 +1,3 @@
-import sortImports from '@ianvs/prettier-plugin-sort-imports';
-import * as tailwind from 'prettier-plugin-tailwindcss';
-import * as toml from 'prettier-plugin-toml';
-
 import { tailwindFunctions } from '@2digits/constants';
 
 import { defineConfig, getTypescriptVersion } from './utils';
@@ -36,5 +32,9 @@ export default defineConfig({
 
   tailwindFunctions,
 
-  plugins: [toml, sortImports, tailwind],
+  plugins: [
+    require.resolve('prettier-plugin-toml'),
+    require.resolve('@ianvs/prettier-plugin-sort-imports'),
+    require.resolve('prettier-plugin-tailwindcss'),
+  ],
 });


### PR DESCRIPTION
🐛 Fixed vscode incompatibilities with prettier v3

docs(changeset): Fixed prettier v3 to support vscode