### PR TITLE
🔧 Updated eslint config to accept void return type

### DIFF
--- a/.changeset/rotten-shirts-pull.md
+++ b/.changeset/rotten-shirts-pull.md
@@ -1,0 +1,5 @@
+---
+"@2digits/eslint-config": minor
+---
+
+Allow returning void for arrow-functions

--- a/packages/eslint-config/src/rules/typescript.ts
+++ b/packages/eslint-config/src/rules/typescript.ts
@@ -30,5 +30,9 @@ export const typescript = defineConfig({
     '@typescript-eslint/no-explicit-any': ['warn'],
     '@typescript-eslint/no-import-type-side-effects': ['error'],
     '@typescript-eslint/no-misused-promises': 'off',
+    '@typescript-eslint/no-confusing-void-expression': [
+      'error',
+      { ignoreArrowShorthand: true, ignoreVoidOperator: true },
+    ],
   },
 });


### PR DESCRIPTION
🔧 Updated eslint config to accept void return type

docs(changeset): Allow returning void for arrow-functions