### PR TITLE
⬆️ Updated pnpm

### DIFF
--- a/.changeset/empty-dolphins-suffer.md
+++ b/.changeset/empty-dolphins-suffer.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Updated eslint-flat-config-utils

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "22.13.1"
-pnpm = "9.15.4"
+pnpm = "9.15.5"
 
 [env]
 FORCE_COLOR = "1"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "turbo": "2.4.0",
     "typescript": "5.7.3"
   },
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@9.15.5",
   "prettier": "@2digits/prettier-config"
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -49,7 +49,7 @@
     "@typescript-eslint/parser": "8.22.0",
     "eslint-config-flat-gitignore": "2.0.0",
     "eslint-config-prettier": "10.0.1",
-    "eslint-flat-config-utils": "2.0.0",
+    "eslint-flat-config-utils": "2.0.1",
     "eslint-plugin-antfu": "3.0.0",
     "eslint-plugin-drizzle": "0.2.3",
     "eslint-plugin-jsdoc": "50.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: 10.0.1
         version: 10.0.1(eslint@9.19.0(jiti@2.4.0))
       eslint-flat-config-utils:
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: 2.0.1
+        version: 2.0.1
       eslint-plugin-antfu:
         specifier: 3.0.0
         version: 3.0.0(eslint@9.19.0(jiti@2.4.0))
@@ -3573,8 +3573,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-flat-config-utils@2.0.0:
-    resolution: {integrity: sha512-AbpYwI9FBmjF6BQ8UcaDCrM750DWEB6UJzEjQEg+iWFP6UX9rGsUGJlMf7sWbW3dOA0klUEwmWGZa5FoynXU/w==}
+  eslint-flat-config-utils@2.0.1:
+    resolution: {integrity: sha512-brf0eAgQ6JlKj3bKfOTuuI7VcCZvi8ZCD1MMTVoEvS/d38j8cByZViLFALH/36+eqB17ukmfmKq3bWzGvizejA==}
 
   eslint-json-compat-utils@0.2.1:
     resolution: {integrity: sha512-YzEodbDyW8DX8bImKhAcCeu/L31Dd/70Bidx2Qex9OFUtgzXLqtfWL4Hr5fM/aCCB8QUZLuJur0S9k6UfgFkfg==}
@@ -11276,7 +11276,7 @@ snapshots:
     dependencies:
       eslint: 9.19.0(jiti@2.4.0)
 
-  eslint-flat-config-utils@2.0.0:
+  eslint-flat-config-utils@2.0.1:
     dependencies:
       pathe: 2.0.2
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updates pnpm package manager from 9.15.4 to 9.15.5 and eslint-flat-config-utils from 2.0.0 to 2.0.1, both being patch version updates for bug fixes.

- Updated `packageManager` to `pnpm@9.15.5` in `/package.json` and `/mise.toml`
- Updated `eslint-flat-config-utils` to `2.0.1` in `/packages/eslint-config/package.json`



<!-- /greptile_comment -->