### PR TITLE
docs(changeset): Updated @eslint-react/eslint-plugin

### DIFF
--- a/.changeset/old-tips-jump.md
+++ b/.changeset/old-tips-jump.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Updated @eslint-react/eslint-plugin

--- a/.changeset/small-geese-live.md
+++ b/.changeset/small-geese-live.md
@@ -1,0 +1,6 @@
+---
+'@2digits/eslint-config': patch
+'@2digits/eslint-plugin': patch
+---
+
+Updated eslint

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@changesets/cli": "2.27.12",
     "@manypkg/cli": "0.23.0",
     "@types/node": "22.13.1",
-    "eslint": "9.19.0",
+    "eslint": "9.20.0",
     "prettier": "3.4.2",
     "turbo": "2.4.0",
     "typescript": "5.7.3"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -31,7 +31,7 @@
   "public": true,
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
-    "eslint": "9.19.0",
+    "eslint": "9.20.0",
     "tsup": "8.3.6",
     "typescript": "5.7.3"
   }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -40,7 +40,7 @@
     "@2digits/constants": "workspace:*",
     "@2digits/eslint-plugin": "workspace:*",
     "@eslint-community/eslint-plugin-eslint-comments": "4.4.1",
-    "@eslint-react/eslint-plugin": "1.26.1",
+    "@eslint-react/eslint-plugin": "1.26.2",
     "@eslint/compat": "1.2.6",
     "@eslint/js": "9.19.0",
     "@graphql-eslint/eslint-plugin": "4.3.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -42,7 +42,7 @@
     "@eslint-community/eslint-plugin-eslint-comments": "4.4.1",
     "@eslint-react/eslint-plugin": "1.26.2",
     "@eslint/compat": "1.2.6",
-    "@eslint/js": "9.19.0",
+    "@eslint/js": "9.20.0",
     "@graphql-eslint/eslint-plugin": "4.3.0",
     "@next/eslint-plugin-next": "15.1.6",
     "@tanstack/eslint-plugin-query": "5.66.0",
@@ -77,7 +77,7 @@
     "@types/eslint__js": "8.42.3",
     "@types/node": "22.13.1",
     "@typescript-eslint/utils": "8.23.0",
-    "eslint": "9.19.0",
+    "eslint": "9.20.0",
     "eslint-typegen": "1.0.0",
     "tsup": "8.3.6",
     "typescript": "5.7.3"

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -5,7 +5,7 @@ import type { Linter } from 'eslint'
 export interface RuleOptions {
   /**
    * Enforce giving proper names to type parameters when there are two or more
-   * @see https://github.com/2digits-agency/configs/blob/@2digits/eslint-plugin@2.3.29/packages/eslint/src/rules/type-param-names.ts
+   * @see https://github.com/2digits-agency/configs/blob/@2digits/eslint-plugin@2.3.30/packages/eslint/src/rules/type-param-names.ts
    */
   '@2digits/type-param-names'?: Linter.RuleEntry<[]>
   /**

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -42,7 +42,7 @@
   "public": true,
   "dependencies": {
     "@typescript-eslint/utils": "8.23.0",
-    "eslint": "9.19.0",
+    "eslint": "9.20.0",
     "magic-regexp": "0.8.0",
     "ts-pattern": "5.6.2"
   },

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
-    "eslint": "9.19.0",
+    "eslint": "9.20.0",
     "prettier": "3.4.2",
     "tsup": "8.3.6",
     "typescript": "5.7.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: 4.4.1
         version: 4.4.1(eslint@9.19.0(jiti@2.4.0))
       '@eslint-react/eslint-plugin':
-        specifier: 1.26.1
-        version: 1.26.1(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
+        specifier: 1.26.2
+        version: 1.26.2(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
       '@eslint/compat':
         specifier: 1.2.6
         version: 1.2.6(eslint@9.19.0(jiti@2.4.0))
@@ -1513,20 +1513,20 @@ packages:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint-react/ast@1.26.1':
-    resolution: {integrity: sha512-h9Z7gO0y382vs+pCsfAYuMSHHCbYywS1t8JHdsbO0GH2C5JQJAUM0n3zjcBckgTk+X4OlJSXD9v0QVlpFDvUlw==}
+  '@eslint-react/ast@1.26.2':
+    resolution: {integrity: sha512-WuljGOJaaiehGkW0aAyuCZIGKfcv/Q1fSl4rvlfWohIDgpp5MFIkBa56drR75WUdNKrrUb3JirnVGIAhegUBIA==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/core@1.26.1':
-    resolution: {integrity: sha512-HRfuZPaB0MVwoHFAN9mdppxdtieSxW2vEG1T+zCz1rXO8sUnrQv9OC5ij3AVhF0AXEL6vqScKGjVOMyLlUE3zA==}
+  '@eslint-react/core@1.26.2':
+    resolution: {integrity: sha512-2mB5hZBL6XmOjDNL3o0h/qHQHuzxGQGYtQQHjD0Yddhde7NU/b4z/oxtrzEInc6Lk2Ry7Rhqi4S49EpwKXWJlQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/eff@1.26.1':
-    resolution: {integrity: sha512-21Mh/qqA6kCKLPpFae9rucDkXRBWH0X1dCz7FYmCxA00UOO4EI9aXPjwj5az1bXvAqAQM9pI/kZ8RrR4TyIUDQ==}
+  '@eslint-react/eff@1.26.2':
+    resolution: {integrity: sha512-7ttz+DPNZl+cHdR5PwU9/ff95VHZmo10icGVX34HyRktJuU2boinWzib5KRg6V1jVwgWuzdvULNXyBd5NVMhhg==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/eslint-plugin@1.26.1':
-    resolution: {integrity: sha512-4WPJdbUY6ZjJyrgfka2SfMhySs1J7i+GbbLVUBgK+zMwAzwgBvdAQtzYzFZDeNwjVGnAgpLtzEHkGc6nccR6ZQ==}
+  '@eslint-react/eslint-plugin@1.26.2':
+    resolution: {integrity: sha512-nTfR32jTLChc0RXKbks2Gf6seMYeqiCGj0qYq+yOmEn/XhcDWVQj86SHIJLFPwvH3LSwDUSgiQzdW9jn/rNv3A==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1535,16 +1535,16 @@ packages:
       typescript:
         optional: true
 
-  '@eslint-react/jsx@1.26.1':
-    resolution: {integrity: sha512-C0QHFJBK6jZ7KlpxicYGgUIk5oVSFO1j/qU3OGwM0iEDe+JudMJeNYffbsEMrWkHtWVsWoVsgECdCiiLkC8F/w==}
+  '@eslint-react/jsx@1.26.2':
+    resolution: {integrity: sha512-lldo9Sd/tZslBN8X7/ZAZXY7UccZZYctrNAoeR8DFMFWLxzvooykixLOl5YkRCWm4uaSmq3r3VNFZ35N2wcbyQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/shared@1.26.1':
-    resolution: {integrity: sha512-vPXVU5yxiysMmmMplk2nK9TO5VqyKfS2MW1SG6d3ydGlcw6qO9MRRwMVVf5UpyFUo4B9varqFsOO2dGui6F4fg==}
+  '@eslint-react/shared@1.26.2':
+    resolution: {integrity: sha512-q/xrNkFe8sHAPjaAuvqyCl3Ls5ly9cfUpAfhAgxYtArNAtIZHvuwu0zrwoHMYk0ZpZi+VlQYwUCtKX8axPXoTw==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/var@1.26.1':
-    resolution: {integrity: sha512-A+2GD1AvL8SI42ZnZGmLnIG6Lfd9hgUq+LYeL8aiB+2ZnA70asePdjV/MVXZHQ6xzUmXw/Ko/UMaA42Eb+PhoA==}
+  '@eslint-react/var@1.26.2':
+    resolution: {integrity: sha512-9abwhGTd4DBxOy5jVF0CnjEYDiRTXg4cbbAulZ+MVqE03KZDWNAVYYEYI5e+YTOcyJbGYY/zPEYmB+c+cUEiyw==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
   '@eslint/compat@1.2.6':
@@ -2633,20 +2633,9 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/scope-manager@8.22.0':
-    resolution: {integrity: sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/scope-manager@8.23.0':
     resolution: {integrity: sha512-OGqo7+dXHqI7Hfm+WqkZjKjsiRtFUQHPdGMXzk5mYXhJUedO7e/Y7i8AK3MyLMgZR93TX4bIzYrfyVjLC+0VSw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/type-utils@8.22.0':
-    resolution: {integrity: sha512-NzE3aB62fDEaGjaAYZE4LH7I1MUwHooQ98Byq0G0y3kkibPJQIXVUspzlFOmOfHhiDLwKzMlWxaNv+/qcZurJA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.8.0'
 
   '@typescript-eslint/type-utils@8.23.0':
     resolution: {integrity: sha512-iIuLdYpQWZKbiH+RkCGc6iu+VwscP5rCtQ1lyQ7TYuKLrcZoeJVpcLiG8DliXVkUxirW/PWlmS+d6yD51L9jvA==}
@@ -2655,31 +2644,14 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/types@8.22.0':
-    resolution: {integrity: sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.23.0':
     resolution: {integrity: sha512-1sK4ILJbCmZOTt9k4vkoulT6/y5CHJ1qUYxqpF1K/DBAd8+ZUL4LlSCxOssuH5m4rUaaN0uS0HlVPvd45zjduQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.22.0':
-    resolution: {integrity: sha512-SJX99NAS2ugGOzpyhMza/tX+zDwjvwAtQFLsBo3GQxiGcvaKlqGBkmZ+Y1IdiSi9h4Q0Lr5ey+Cp9CGWNY/F/w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.8.0'
 
   '@typescript-eslint/typescript-estree@8.23.0':
     resolution: {integrity: sha512-LcqzfipsB8RTvH8FX24W4UUFk1bl+0yTOf9ZA08XngFwMg4Kj8A+9hwz8Cr/ZS4KwHrmo9PJiLZkOt49vPnuvQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <5.8.0'
-
-  '@typescript-eslint/utils@8.22.0':
-    resolution: {integrity: sha512-T8oc1MbF8L+Bk2msAvCUzjxVB2Z2f+vXYfcucE2wOmYs7ZUwco5Ep0fYZw8quNwOiw9K8GYVL+Kgc2pETNTLOg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
   '@typescript-eslint/utils@8.23.0':
@@ -2688,10 +2660,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
-
-  '@typescript-eslint/visitor-keys@8.22.0':
-    resolution: {integrity: sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.23.0':
     resolution: {integrity: sha512-oWWhcWDLwDfu++BGTZcmXWqpwtkwb5o7fxUIGksMQQDSdPW9prsSnfIOZMlsj4vBOSrcnjIUZMiIjODgGosFhQ==}
@@ -3659,8 +3627,8 @@ packages:
     peerDependencies:
       eslint: '>=7'
 
-  eslint-plugin-react-debug@1.26.1:
-    resolution: {integrity: sha512-DHwCl4wX6B33WVav8qKLCnRo98bjSkz+9FK1VIBLAngqNLX5xTQNz4mrPp3Yxtdv1z0q528EB/7e62DAX4nJYw==}
+  eslint-plugin-react-debug@1.26.2:
+    resolution: {integrity: sha512-UKCXj090YGXYmVLfZ8yZh09RLPlMfhJFYRXGUL4i/IHal22PO7kNTwNSHw105THVJXTiKPxuj/dDbII3H2C+7w==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -3669,8 +3637,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-dom@1.26.1:
-    resolution: {integrity: sha512-fiHTZ8SGDr0LCayg5h/rHP1+TW53g87jXFTyly7i9YZP7nHLyr0CZJ7D888XCWK2JY5hszbKn6tKOU0DdS7Xiw==}
+  eslint-plugin-react-dom@1.26.2:
+    resolution: {integrity: sha512-W4PLB5+zRt+Ceewtwf2tobEPBF+Pvl5ycElRPeKT9VOpn6IAqk0i5JqCVu7mPvPruLFbUDlGaHK769aZhqLyjA==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -3679,8 +3647,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-hooks-extra@1.26.1:
-    resolution: {integrity: sha512-WgGaEUI7W84JvyCLAVI4yAm1iNDMjedOxj7x7V1XXdiPIao6w/9CJQQi87G8O0Uu8LSrU5OooPICB7vOVXwKpQ==}
+  eslint-plugin-react-hooks-extra@1.26.2:
+    resolution: {integrity: sha512-Xh1Pp6lvYDI8aOFDvtd1E6WzBE3QVk2cV48pmKQOWzzL25Tod/7kk4pOXoML1t1rqRQW8xcoL7UmrlR8IMQh+w==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -3695,8 +3663,8 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
-  eslint-plugin-react-naming-convention@1.26.1:
-    resolution: {integrity: sha512-EwpsGuX8pUe7IjwC/+hzTAcaUAb/hEW+InRIon6rPdKlI02R25bOpTPcylD37ut164Z5Aw0g/4X0Q3M7S3Xdgw==}
+  eslint-plugin-react-naming-convention@1.26.2:
+    resolution: {integrity: sha512-eiudTnDwwVpOY6K2g2fsoklG3x4X7N0X4+wFM2AE0+qSy4TCCFic+H+NRi3T53nL0pbvNawHkjS8sRSRRzOG3A==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -3705,8 +3673,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-web-api@1.26.1:
-    resolution: {integrity: sha512-09k3gcy1BWn39hzNehgRtvC5fdMtdEGOXMTDS9OZEjrFMeWB9NcuzHv49p9iEbN2Cf/UjOEbdqDwf1vWtP4iGQ==}
+  eslint-plugin-react-web-api@1.26.2:
+    resolution: {integrity: sha512-xu0QWvptg9zDaf/hfiJ02hTOd/soF10ww3h9wnJZ7ohbMclIA89ZRET6lXXXJNie3HrOLsB+HmOg/h/Rc7zL+A==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -3715,12 +3683,12 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-x@1.26.1:
-    resolution: {integrity: sha512-m8W8vLS0l2xTD8d+QFPebHXblyZEJ4Wyg4REKNdLfbHHgdtaVKvOtFKMnVGwnL4gRHG1DyFlZzQJIgHy53hpfw==}
+  eslint-plugin-react-x@1.26.2:
+    resolution: {integrity: sha512-4wEHGPdCY8yNl0AYcZWDdQ6QyX7lRmjoaM7CSw3v9ZEHLh2u8ttKl2JJpx5mRKFWP0JxQ8YvbgLW8MovDAIWmw==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      ts-api-utils: ^2.0.0
+      ts-api-utils: ^2.0.1
       typescript: ^4.9.5 || ^5.3.3
     peerDependenciesMeta:
       ts-api-utils:
@@ -6057,8 +6025,8 @@ packages:
   string-env-interpolation@1.0.1:
     resolution: {integrity: sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==}
 
-  string-ts@2.2.0:
-    resolution: {integrity: sha512-VTP0LLZo4Jp9Gz5IiDVMS9WyLx/3IeYh0PXUn0NdPqusUFNgkHPWiEdbB9TU2Iv3myUskraD5WtYEdHUrQEIlQ==}
+  string-ts@2.2.1:
+    resolution: {integrity: sha512-Q2u0gko67PLLhbte5HmPfdOjNvUKbKQM+mCNQae6jE91DmoFHY6HH9GcdqCeNx87DZ2KKjiFxmA0R/42OneGWw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -6258,12 +6226,6 @@ packages:
 
   trough@1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
-
-  ts-api-utils@2.0.0:
-    resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
 
   ts-api-utils@2.0.1:
     resolution: {integrity: sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==}
@@ -8768,29 +8730,29 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint-react/ast@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/ast@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/eff': 1.26.1
-      '@typescript-eslint/types': 8.22.0
-      '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@typescript-eslint/types': 8.23.0
+      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      string-ts: 2.2.0
+      string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
 
-  '@eslint-react/core@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/core@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/eff': 1.26.1
-      '@eslint-react/jsx': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       birecord: 0.1.1
       ts-pattern: 5.6.2
@@ -8799,36 +8761,36 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/eff@1.26.1': {}
+  '@eslint-react/eff@1.26.2': {}
 
-  '@eslint-react/eslint-plugin@1.26.1(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)':
+  '@eslint-react/eslint-plugin@1.26.2(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/eff': 1.26.1
-      '@eslint-react/shared': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/eff': 1.26.2
+      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.0)
-      eslint-plugin-react-debug: 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-dom: 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-hooks-extra: 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-naming-convention: 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-web-api: 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-x: 1.26.1(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
+      eslint-plugin-react-debug: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-dom: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-hooks-extra: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-naming-convention: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-web-api: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-x: 1.26.2(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
       - ts-api-utils
 
-  '@eslint-react/jsx@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/jsx@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/eff': 1.26.1
-      '@eslint-react/var': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8836,9 +8798,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/shared@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/shared@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/eff': 1.26.1
+      '@eslint-react/eff': 1.26.2
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       picomatch: 4.0.2
       ts-pattern: 5.6.2
@@ -8847,14 +8809,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/var@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/var@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/eff': 1.26.1
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      string-ts: 2.2.0
+      string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
       - eslint
@@ -10236,26 +10198,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.22.0':
-    dependencies:
-      '@typescript-eslint/types': 8.22.0
-      '@typescript-eslint/visitor-keys': 8.22.0
-
   '@typescript-eslint/scope-manager@8.23.0':
     dependencies:
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/visitor-keys': 8.23.0
-
-  '@typescript-eslint/type-utils@8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      debug: 4.4.0
-      eslint: 9.19.0(jiti@2.4.0)
-      ts-api-utils: 2.0.0(typescript@5.7.3)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/type-utils@8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
@@ -10268,23 +10214,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.22.0': {}
-
   '@typescript-eslint/types@8.23.0': {}
-
-  '@typescript-eslint/typescript-estree@8.22.0(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.22.0
-      '@typescript-eslint/visitor-keys': 8.22.0
-      debug: 4.4.0
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 2.0.0(typescript@5.7.3)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/typescript-estree@8.23.0(typescript@5.7.3)':
     dependencies:
@@ -10300,17 +10230,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.0))
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/types': 8.22.0
-      '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/utils@8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.0))
@@ -10321,11 +10240,6 @@ snapshots:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/visitor-keys@8.22.0':
-    dependencies:
-      '@typescript-eslint/types': 8.22.0
-      eslint-visitor-keys: 4.2.0
 
   '@typescript-eslint/visitor-keys@8.23.0':
     dependencies:
@@ -11447,60 +11361,60 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-debug@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-debug@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/eff': 1.26.1
-      '@eslint-react/jsx': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.0)
-      string-ts: 2.2.0
+      string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-dom@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-dom@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/eff': 1.26.1
-      '@eslint-react/jsx': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       compare-versions: 6.1.1
       eslint: 9.19.0(jiti@2.4.0)
-      string-ts: 2.2.0
+      string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks-extra@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-hooks-extra@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/eff': 1.26.1
-      '@eslint-react/jsx': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.0)
-      string-ts: 2.2.0
+      string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
       typescript: 5.7.3
@@ -11511,60 +11425,60 @@ snapshots:
     dependencies:
       eslint: 9.19.0(jiti@2.4.0)
 
-  eslint-plugin-react-naming-convention@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-naming-convention@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/eff': 1.26.1
-      '@eslint-react/jsx': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.0)
-      string-ts: 2.2.0
+      string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-web-api@1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-web-api@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/eff': 1.26.1
-      '@eslint-react/jsx': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.0)
-      string-ts: 2.2.0
+      string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@1.26.1(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3):
+  eslint-plugin-react-x@1.26.2(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/eff': 1.26.1
-      '@eslint-react/jsx': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/types': 8.22.0
+      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/eff': 1.26.2
+      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       compare-versions: 6.1.1
       eslint: 9.19.0(jiti@2.4.0)
       is-immutable-type: 5.0.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      string-ts: 2.2.0
+      string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
       ts-api-utils: 2.0.1(typescript@5.7.3)
@@ -12441,9 +12355,9 @@ snapshots:
 
   is-immutable-type@5.0.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.0)
-      ts-api-utils: 2.0.0(typescript@5.7.3)
+      ts-api-utils: 2.0.1(typescript@5.7.3)
       ts-declaration-location: 1.0.4(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -14333,7 +14247,7 @@ snapshots:
 
   string-env-interpolation@1.0.1: {}
 
-  string-ts@2.2.0: {}
+  string-ts@2.2.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -14590,10 +14504,6 @@ snapshots:
       uglify-js: 3.19.3
 
   trough@1.0.5: {}
-
-  ts-api-utils@2.0.0(typescript@5.7.3):
-    dependencies:
-      typescript: 5.7.3
 
   ts-api-utils@2.0.1(typescript@5.7.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 22.13.1
         version: 22.13.1
       eslint:
-        specifier: 9.19.0
-        version: 9.19.0(jiti@2.4.0)
+        specifier: 9.20.0
+        version: 9.20.0(jiti@2.4.0)
       prettier:
         specifier: 3.4.2
         version: 3.4.2
@@ -45,8 +45,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       eslint:
-        specifier: 9.19.0
-        version: 9.19.0(jiti@2.4.0)
+        specifier: 9.20.0
+        version: 9.20.0(jiti@2.4.0)
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.0)(postcss@8.4.40)(typescript@5.7.3)(yaml@2.7.0)
@@ -64,79 +64,79 @@ importers:
         version: link:../eslint-plugin
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.4.1
-        version: 4.4.1(eslint@9.19.0(jiti@2.4.0))
+        version: 4.4.1(eslint@9.20.0(jiti@2.4.0))
       '@eslint-react/eslint-plugin':
         specifier: 1.26.2
-        version: 1.26.2(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
+        version: 1.26.2(eslint@9.20.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
       '@eslint/compat':
         specifier: 1.2.6
-        version: 1.2.6(eslint@9.19.0(jiti@2.4.0))
+        version: 1.2.6(eslint@9.20.0(jiti@2.4.0))
       '@eslint/js':
-        specifier: 9.19.0
-        version: 9.19.0
+        specifier: 9.20.0
+        version: 9.20.0
       '@graphql-eslint/eslint-plugin':
         specifier: 4.3.0
-        version: 4.3.0(@types/node@22.13.1)(encoding@0.1.13)(eslint@9.19.0(jiti@2.4.0))(graphql@16.8.2)(typescript@5.7.3)
+        version: 4.3.0(@types/node@22.13.1)(encoding@0.1.13)(eslint@9.20.0(jiti@2.4.0))(graphql@16.8.2)(typescript@5.7.3)
       '@next/eslint-plugin-next':
         specifier: 15.1.6
         version: 15.1.6
       '@tanstack/eslint-plugin-query':
         specifier: 5.66.0
-        version: 5.66.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 5.66.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/parser':
         specifier: 8.23.0
-        version: 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint-config-flat-gitignore:
         specifier: 2.0.0
-        version: 2.0.0(eslint@9.19.0(jiti@2.4.0))
+        version: 2.0.0(eslint@9.20.0(jiti@2.4.0))
       eslint-config-prettier:
         specifier: 10.0.1
-        version: 10.0.1(eslint@9.19.0(jiti@2.4.0))
+        version: 10.0.1(eslint@9.20.0(jiti@2.4.0))
       eslint-flat-config-utils:
         specifier: 2.0.1
         version: 2.0.1
       eslint-plugin-antfu:
         specifier: 3.0.0
-        version: 3.0.0(eslint@9.19.0(jiti@2.4.0))
+        version: 3.0.0(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-drizzle:
         specifier: 0.2.3
-        version: 0.2.3(eslint@9.19.0(jiti@2.4.0))
+        version: 0.2.3(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-jsdoc:
         specifier: 50.6.3
-        version: 50.6.3(eslint@9.19.0(jiti@2.4.0))
+        version: 50.6.3(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-jsonc:
         specifier: 2.19.1
-        version: 2.19.1(eslint@9.19.0(jiti@2.4.0))
+        version: 2.19.1(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-n:
         specifier: 17.15.1
-        version: 17.15.1(eslint@9.19.0(jiti@2.4.0))
+        version: 17.15.1(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-react:
         specifier: 7.37.4
-        version: 7.37.4(eslint@9.19.0(jiti@2.4.0))
+        version: 7.37.4(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-react-compiler:
         specifier: 19.0.0-beta-e552027-20250112
-        version: 19.0.0-beta-e552027-20250112(eslint@9.19.0(jiti@2.4.0))
+        version: 19.0.0-beta-e552027-20250112(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-react-hooks:
         specifier: 5.1.0
-        version: 5.1.0(eslint@9.19.0(jiti@2.4.0))
+        version: 5.1.0(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-regexp:
         specifier: 2.7.0
-        version: 2.7.0(eslint@9.19.0(jiti@2.4.0))
+        version: 2.7.0(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-sonarjs:
         specifier: 3.0.1
-        version: 3.0.1(eslint@9.19.0(jiti@2.4.0))
+        version: 3.0.1(eslint@9.20.0(jiti@2.4.0))
       eslint-plugin-storybook:
         specifier: 0.11.2
-        version: 0.11.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 0.11.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint-plugin-tailwindcss:
         specifier: 3.18.0
         version: 3.18.0(tailwindcss@3.4.4)
       eslint-plugin-turbo:
         specifier: 2.4.0
-        version: 2.4.0(eslint@9.19.0(jiti@2.4.0))(turbo@2.4.0)
+        version: 2.4.0(eslint@9.20.0(jiti@2.4.0))(turbo@2.4.0)
       eslint-plugin-unicorn:
         specifier: 56.0.1
-        version: 56.0.1(eslint@9.19.0(jiti@2.4.0))
+        version: 56.0.1(eslint@9.20.0(jiti@2.4.0))
       find-up:
         specifier: 7.0.0
         version: 7.0.0
@@ -154,14 +154,14 @@ importers:
         version: 1.0.0
       typescript-eslint:
         specifier: 8.23.0
-        version: 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
     devDependencies:
       '@2digits/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       '@eslint/config-inspector':
         specifier: 1.0.0
-        version: 1.0.0(eslint@9.19.0(jiti@2.4.0))
+        version: 1.0.0(eslint@9.20.0(jiti@2.4.0))
       '@types/eslint__js':
         specifier: 8.42.3
         version: 8.42.3
@@ -170,13 +170,13 @@ importers:
         version: 22.13.1
       '@typescript-eslint/utils':
         specifier: 8.23.0
-        version: 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint:
-        specifier: 9.19.0
-        version: 9.19.0(jiti@2.4.0)
+        specifier: 9.20.0
+        version: 9.20.0(jiti@2.4.0)
       eslint-typegen:
         specifier: 1.0.0
-        version: 1.0.0(eslint@9.19.0(jiti@2.4.0))
+        version: 1.0.0(eslint@9.20.0(jiti@2.4.0))
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.0)(postcss@8.4.40)(typescript@5.7.3)(yaml@2.7.0)
@@ -188,10 +188,10 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: 8.23.0
-        version: 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint:
-        specifier: 9.19.0
-        version: 9.19.0(jiti@2.4.0)
+        specifier: 9.20.0
+        version: 9.20.0(jiti@2.4.0)
       magic-regexp:
         specifier: 0.8.0
         version: 0.8.0
@@ -204,10 +204,10 @@ importers:
         version: link:../tsconfig
       '@typescript-eslint/parser':
         specifier: 8.23.0
-        version: 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint-vitest-rule-tester:
         specifier: 1.1.0
-        version: 1.1.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1))
+        version: 1.1.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1))
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.0)(postcss@8.4.40)(typescript@5.7.3)(yaml@2.7.0)
@@ -252,8 +252,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       eslint:
-        specifier: 9.19.0
-        version: 9.19.0(jiti@2.4.0)
+        specifier: 9.20.0
+        version: 9.20.0(jiti@2.4.0)
       prettier:
         specifier: 3.4.2
         version: 3.4.2
@@ -1570,12 +1570,16 @@ packages:
     resolution: {integrity: sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/core@0.11.0':
+    resolution: {integrity: sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@3.2.0':
     resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.19.0':
-    resolution: {integrity: sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==}
+  '@eslint/js@9.20.0':
+    resolution: {integrity: sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.4':
@@ -3768,8 +3772,8 @@ packages:
       eslint: ^9.0.0
       vitest: ^1.0.0 || ^2.0.0 || ^3.0.0
 
-  eslint@9.19.0:
-    resolution: {integrity: sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==}
+  eslint@9.20.0:
+    resolution: {integrity: sha512-aL4F8167Hg4IvsW89ejnpTwx+B/UQRzJPGgbIOl+4XqffWsahVVsLEWoZvnrVuwpWmnRd7XeXmQI1zlKcFDteA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -7603,11 +7607,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.25.9(@babel/core@7.26.0)(eslint@9.19.0(jiti@2.4.0))':
+  '@babel/eslint-parser@7.25.9(@babel/core@7.26.0)(eslint@9.20.0(jiti@2.4.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -8717,25 +8721,25 @@ snapshots:
   '@esbuild/win32-x64@0.24.2':
     optional: true
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.4.1(eslint@9.19.0(jiti@2.4.0))':
+  '@eslint-community/eslint-plugin-eslint-comments@4.4.1(eslint@9.20.0(jiti@2.4.0))':
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       ignore: 5.3.1
 
-  '@eslint-community/eslint-utils@4.4.1(eslint@9.19.0(jiti@2.4.0))':
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.20.0(jiti@2.4.0))':
     dependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint-react/ast@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/ast@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@eslint-react/eff': 1.26.2
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8743,17 +8747,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/core@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/core@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       birecord: 0.1.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8763,45 +8767,45 @@ snapshots:
 
   '@eslint-react/eff@1.26.2': {}
 
-  '@eslint-react/eslint-plugin@1.26.2(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)':
+  '@eslint-react/eslint-plugin@1.26.2(eslint@9.20.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
-      eslint-plugin-react-debug: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-dom: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-hooks-extra: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-naming-convention: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-web-api: 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-x: 1.26.2(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
+      eslint-plugin-react-debug: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-dom: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-hooks-extra: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-naming-convention: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-web-api: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-x: 1.26.2(eslint@9.20.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
       - ts-api-utils
 
-  '@eslint-react/jsx@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/jsx@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       ts-pattern: 5.6.2
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
 
-  '@eslint-react/shared@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/shared@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@eslint-react/eff': 1.26.2
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       picomatch: 4.0.2
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8809,13 +8813,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/var@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/var@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8823,9 +8827,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint/compat@1.2.6(eslint@9.19.0(jiti@2.4.0))':
+  '@eslint/compat@1.2.6(eslint@9.20.0(jiti@2.4.0))':
     optionalDependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
 
   '@eslint/config-array@0.19.0':
     dependencies:
@@ -8835,7 +8839,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-inspector@1.0.0(eslint@9.19.0(jiti@2.4.0))':
+  '@eslint/config-inspector@1.0.0(eslint@9.20.0(jiti@2.4.0))':
     dependencies:
       '@nodelib/fs.walk': 3.0.1
       bundle-require: 5.1.0(esbuild@0.24.2)
@@ -8843,7 +8847,7 @@ snapshots:
       chokidar: 4.0.3
       debug: 4.4.0
       esbuild: 0.24.2
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       fast-glob: 3.3.3
       find-up: 7.0.0
       get-port-please: 3.1.2
@@ -8862,6 +8866,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/core@0.11.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
@@ -8876,7 +8884,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.19.0': {}
+  '@eslint/js@9.20.0': {}
 
   '@eslint/object-schema@2.1.4': {}
 
@@ -8885,13 +8893,13 @@ snapshots:
       '@eslint/core': 0.10.0
       levn: 0.4.1
 
-  '@graphql-eslint/eslint-plugin@4.3.0(@types/node@22.13.1)(encoding@0.1.13)(eslint@9.19.0(jiti@2.4.0))(graphql@16.8.2)(typescript@5.7.3)':
+  '@graphql-eslint/eslint-plugin@4.3.0(@types/node@22.13.1)(encoding@0.1.13)(eslint@9.20.0(jiti@2.4.0))(graphql@16.8.2)(typescript@5.7.3)':
     dependencies:
       '@graphql-tools/code-file-loader': 8.1.6(graphql@16.8.2)
       '@graphql-tools/graphql-tag-pluck': 8.3.5(graphql@16.8.2)
       '@graphql-tools/utils': 10.6.0(graphql@16.8.2)
       debug: 4.3.7
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       fast-glob: 3.3.2
       graphql: 16.8.2
       graphql-config: 5.1.3(@types/node@22.13.1)(encoding@0.1.13)(graphql@16.8.2)(typescript@5.7.3)
@@ -10031,10 +10039,10 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/eslint-plugin-query@5.66.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@tanstack/eslint-plugin-query@5.66.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10169,15 +10177,15 @@ snapshots:
       '@types/node': 22.13.1
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.23.0
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -10186,14 +10194,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.23.0
       debug: 4.4.0
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -10203,12 +10211,12 @@ snapshots:
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/visitor-keys': 8.23.0
 
-  '@typescript-eslint/type-utils@8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       debug: 4.4.0
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       ts-api-utils: 2.0.1(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -10230,13 +10238,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -11262,58 +11270,58 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@9.19.0(jiti@2.4.0)):
+  eslint-compat-utils@0.5.1(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       semver: 7.6.3
 
-  eslint-compat-utils@0.6.4(eslint@9.19.0(jiti@2.4.0)):
+  eslint-compat-utils@0.6.4(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       semver: 7.6.3
 
-  eslint-config-flat-gitignore@2.0.0(eslint@9.19.0(jiti@2.4.0)):
+  eslint-config-flat-gitignore@2.0.0(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      '@eslint/compat': 1.2.6(eslint@9.19.0(jiti@2.4.0))
-      eslint: 9.19.0(jiti@2.4.0)
+      '@eslint/compat': 1.2.6(eslint@9.20.0(jiti@2.4.0))
+      eslint: 9.20.0(jiti@2.4.0)
 
-  eslint-config-prettier@10.0.1(eslint@9.19.0(jiti@2.4.0)):
+  eslint-config-prettier@10.0.1(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
 
   eslint-flat-config-utils@2.0.1:
     dependencies:
       pathe: 2.0.2
 
-  eslint-json-compat-utils@0.2.1(eslint@9.19.0(jiti@2.4.0))(jsonc-eslint-parser@2.4.0):
+  eslint-json-compat-utils@0.2.1(eslint@9.20.0(jiti@2.4.0))(jsonc-eslint-parser@2.4.0):
     dependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       esquery: 1.6.0
       jsonc-eslint-parser: 2.4.0
 
-  eslint-plugin-antfu@3.0.0(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-antfu@3.0.0(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
 
-  eslint-plugin-drizzle@0.2.3(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-drizzle@0.2.3(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
 
-  eslint-plugin-es-x@7.8.0(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-es-x@7.8.0(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
       '@eslint-community/regexpp': 4.12.1
-      eslint: 9.19.0(jiti@2.4.0)
-      eslint-compat-utils: 0.5.1(eslint@9.19.0(jiti@2.4.0))
+      eslint: 9.20.0(jiti@2.4.0)
+      eslint-compat-utils: 0.5.1(eslint@9.20.0(jiti@2.4.0))
 
-  eslint-plugin-jsdoc@50.6.3(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-jsdoc@50.6.3(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
       '@es-joy/jsdoccomment': 0.49.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
       debug: 4.4.0
       escape-string-regexp: 4.0.0
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       espree: 10.3.0
       esquery: 1.6.0
       parse-imports: 2.1.1
@@ -11323,12 +11331,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsonc@2.19.1(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-jsonc@2.19.1(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.0))
-      eslint: 9.19.0(jiti@2.4.0)
-      eslint-compat-utils: 0.6.4(eslint@9.19.0(jiti@2.4.0))
-      eslint-json-compat-utils: 0.2.1(eslint@9.19.0(jiti@2.4.0))(jsonc-eslint-parser@2.4.0)
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
+      eslint: 9.20.0(jiti@2.4.0)
+      eslint-compat-utils: 0.6.4(eslint@9.20.0(jiti@2.4.0))
+      eslint-json-compat-utils: 0.2.1(eslint@9.20.0(jiti@2.4.0))(jsonc-eslint-parser@2.4.0)
       espree: 9.6.1
       graphemer: 1.4.0
       jsonc-eslint-parser: 2.4.0
@@ -11337,43 +11345,43 @@ snapshots:
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-n@17.15.1(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-n@17.15.1(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
       enhanced-resolve: 5.17.1
-      eslint: 9.19.0(jiti@2.4.0)
-      eslint-plugin-es-x: 7.8.0(eslint@9.19.0(jiti@2.4.0))
+      eslint: 9.20.0(jiti@2.4.0)
+      eslint-plugin-es-x: 7.8.0(eslint@9.20.0(jiti@2.4.0))
       get-tsconfig: 4.8.1
       globals: 15.14.0
       ignore: 5.3.2
       minimatch: 9.0.5
       semver: 7.6.3
 
-  eslint-plugin-react-compiler@19.0.0-beta-e552027-20250112(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-react-compiler@19.0.0-beta-e552027-20250112(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
       '@babel/core': 7.24.6
       '@babel/parser': 7.26.2
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.24.6)
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       hermes-parser: 0.25.1
       zod: 3.24.1
       zod-validation-error: 3.3.0(zod@3.24.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-debug@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-debug@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11381,19 +11389,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-dom@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-dom@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       compare-versions: 6.1.1
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11401,19 +11409,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks-extra@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-hooks-extra@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11421,22 +11429,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@5.1.0(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-react-hooks@5.1.0(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
 
-  eslint-plugin-react-naming-convention@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-naming-convention@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11444,18 +11452,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-web-api@1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-web-api@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11463,21 +11471,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@1.26.2(eslint@9.19.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3):
+  eslint-plugin-react-x@1.26.2(eslint@9.20.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       compare-versions: 6.1.1
-      eslint: 9.19.0(jiti@2.4.0)
-      is-immutable-type: 5.0.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
+      is-immutable-type: 5.0.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11486,7 +11494,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.4(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-react@7.37.4(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
@@ -11494,7 +11502,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -11508,21 +11516,21 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-regexp@2.7.0(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-regexp@2.7.0(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
       '@eslint-community/regexpp': 4.12.1
       comment-parser: 1.4.1
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       jsdoc-type-pratt-parser: 4.1.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-sonarjs@3.0.1(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-sonarjs@3.0.1(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/eslint-parser': 7.25.9(@babel/core@7.26.0)(eslint@9.19.0(jiti@2.4.0))
+      '@babel/eslint-parser': 7.25.9(@babel/core@7.26.0)(eslint@9.20.0(jiti@2.4.0))
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/preset-flow': 7.25.9(@babel/core@7.26.0)
@@ -11530,7 +11538,7 @@ snapshots:
       '@eslint-community/regexpp': 4.12.1
       builtin-modules: 3.3.0
       bytes: 3.1.2
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       functional-red-black-tree: 1.0.1
       jsx-ast-utils: 3.3.5
       minimatch: 9.0.5
@@ -11540,11 +11548,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-storybook@0.11.2(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-storybook@0.11.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
       '@storybook/csf': 0.1.11
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -11556,20 +11564,20 @@ snapshots:
       postcss: 8.4.40
       tailwindcss: 3.4.4
 
-  eslint-plugin-turbo@2.4.0(eslint@9.19.0(jiti@2.4.0))(turbo@2.4.0):
+  eslint-plugin-turbo@2.4.0(eslint@9.20.0(jiti@2.4.0))(turbo@2.4.0):
     dependencies:
       dotenv: 16.0.3
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       turbo: 2.4.0
 
-  eslint-plugin-unicorn@56.0.1(eslint@9.19.0(jiti@2.4.0)):
+  eslint-plugin-unicorn@56.0.1(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
       ci-info: 4.0.0
       clean-regexp: 1.0.0
       core-js-compat: 3.38.1
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       esquery: 1.6.0
       globals: 15.14.0
       indent-string: 4.0.0
@@ -11592,9 +11600,9 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-typegen@1.0.0(eslint@9.19.0(jiti@2.4.0)):
+  eslint-typegen@1.0.0(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
-      eslint: 9.19.0(jiti@2.4.0)
+      eslint: 9.20.0(jiti@2.4.0)
       json-schema-to-typescript-lite: 14.1.0
       ohash: 1.1.4
 
@@ -11604,25 +11612,25 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint-vitest-rule-tester@1.1.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)):
+  eslint-vitest-rule-tester@1.1.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)):
     dependencies:
       '@antfu/utils': 8.1.0
       '@types/eslint': 9.6.1
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
       vitest: 3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint@9.19.0(jiti@2.4.0):
+  eslint@9.20.0(jiti@2.4.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.19.0
-      '@eslint/core': 0.10.0
+      '@eslint/core': 0.11.0
       '@eslint/eslintrc': 3.2.0
-      '@eslint/js': 9.19.0
+      '@eslint/js': 9.20.0
       '@eslint/plugin-kit': 0.2.5
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
@@ -12353,10 +12361,10 @@ snapshots:
 
   is-hexadecimal@1.0.4: {}
 
-  is-immutable-type@5.0.1(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  is-immutable-type@5.0.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
       ts-api-utils: 2.0.1(typescript@5.7.3)
       ts-declaration-location: 1.0.4(typescript@5.7.3)
       typescript: 5.7.3
@@ -14654,12 +14662,12 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3):
+  typescript-eslint@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.19.0(jiti@2.4.0)
+      '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updates ESLint and related dependencies across the monorepo, including a minor version bump of @eslint-react/eslint-plugin from 1.26.1 to 1.26.2 and ESLint core from 9.19.0 to 9.20.0.

- Updated ESLint from 9.19.0 to 9.20.0 consistently across all workspace packages in `/packages/**/package.json`
- Bumped `@eslint-react/eslint-plugin` from 1.26.1 to 1.26.2 in `/packages/eslint-config/package.json`
- Bumped `@eslint/js` from 9.19.0 to 9.20.0 in `/packages/eslint-config/package.json`



<!-- /greptile_comment -->