### PR TITLE
⬆️ Updated node and pnpm

### DIFF
--- a/.changeset/dirty-ways-laugh.md
+++ b/.changeset/dirty-ways-laugh.md
@@ -1,0 +1,6 @@
+---
+'@2digits/eslint-config': patch
+'@2digits/eslint-plugin': patch
+---
+
+Updated typescript-eslint

--- a/.changeset/honest-sloths-smash.md
+++ b/.changeset/honest-sloths-smash.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Updated @next/eslint-plugin-next

--- a/.changeset/nervous-bees-look.md
+++ b/.changeset/nervous-bees-look.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Updated @tanstack/eslint-plugin-query

--- a/.changeset/sour-rings-remember.md
+++ b/.changeset/sour-rings-remember.md
@@ -1,0 +1,6 @@
+---
+'@2digits/eslint-config': patch
+'@2digits/eslint-plugin': patch
+---
+
+Updated eslint

--- a/.changeset/tame-panthers-hunt.md
+++ b/.changeset/tame-panthers-hunt.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Updated turbo

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,10 @@
 [tools]
-node = "22.13.1"
-pnpm = "10.2.1"
+node = "22.14.0"
+pnpm = "10.3.0"
 
 [env]
 FORCE_COLOR = "1"
 NODE_OPTIONS = "--no-deprecation"
+
+[settings]
+pin = true

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/node": "22.13.1",
     "eslint": "9.20.0",
     "prettier": "3.5.0",
-    "turbo": "2.4.0",
+    "turbo": "2.4.1",
     "typescript": "5.7.3"
   },
   "packageManager": "pnpm@10.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "turbo": "2.4.0",
     "typescript": "5.7.3"
   },
-  "packageManager": "pnpm@10.2.1",
+  "packageManager": "pnpm@10.3.0",
   "prettier": "@2digits/prettier-config",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@changesets/cli": "2.27.12",
     "@manypkg/cli": "0.23.0",
     "@types/node": "22.13.1",
-    "eslint": "9.20.0",
+    "eslint": "9.20.1",
     "prettier": "3.5.0",
     "turbo": "2.4.1",
     "typescript": "5.7.3"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -31,7 +31,7 @@
   "public": true,
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
-    "eslint": "9.20.0",
+    "eslint": "9.20.1",
     "tsup": "8.3.6",
     "typescript": "5.7.3"
   }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -44,7 +44,7 @@
     "@eslint/compat": "1.2.6",
     "@eslint/js": "9.20.0",
     "@graphql-eslint/eslint-plugin": "4.3.0",
-    "@next/eslint-plugin-next": "15.1.6",
+    "@next/eslint-plugin-next": "15.1.7",
     "@tanstack/eslint-plugin-query": "5.66.0",
     "@typescript-eslint/parser": "8.23.0",
     "eslint-config-flat-gitignore": "2.0.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -46,7 +46,7 @@
     "@graphql-eslint/eslint-plugin": "4.3.0",
     "@next/eslint-plugin-next": "15.1.7",
     "@tanstack/eslint-plugin-query": "5.66.1",
-    "@typescript-eslint/parser": "8.23.0",
+    "@typescript-eslint/parser": "8.24.0",
     "eslint-config-flat-gitignore": "2.0.0",
     "eslint-config-prettier": "10.0.1",
     "eslint-flat-config-utils": "2.0.1",
@@ -69,14 +69,14 @@
     "graphql-config": "5.1.3",
     "jsonc-eslint-parser": "2.4.0",
     "local-pkg": "1.0.0",
-    "typescript-eslint": "8.23.0"
+    "typescript-eslint": "8.24.0"
   },
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
     "@eslint/config-inspector": "1.0.0",
     "@types/eslint__js": "8.42.3",
     "@types/node": "22.13.1",
-    "@typescript-eslint/utils": "8.23.0",
+    "@typescript-eslint/utils": "8.24.0",
     "eslint": "9.20.0",
     "eslint-typegen": "1.0.0",
     "tsup": "8.3.6",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -45,7 +45,7 @@
     "@eslint/js": "9.20.0",
     "@graphql-eslint/eslint-plugin": "4.3.0",
     "@next/eslint-plugin-next": "15.1.7",
-    "@tanstack/eslint-plugin-query": "5.66.0",
+    "@tanstack/eslint-plugin-query": "5.66.1",
     "@typescript-eslint/parser": "8.23.0",
     "eslint-config-flat-gitignore": "2.0.0",
     "eslint-config-prettier": "10.0.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -77,7 +77,7 @@
     "@types/eslint__js": "8.42.3",
     "@types/node": "22.13.1",
     "@typescript-eslint/utils": "8.24.0",
-    "eslint": "9.20.0",
+    "eslint": "9.20.1",
     "eslint-typegen": "1.0.0",
     "tsup": "8.3.6",
     "typescript": "5.7.3"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-sonarjs": "3.0.1",
     "eslint-plugin-storybook": "0.11.2",
     "eslint-plugin-tailwindcss": "3.18.0",
-    "eslint-plugin-turbo": "2.4.0",
+    "eslint-plugin-turbo": "2.4.1",
     "eslint-plugin-unicorn": "56.0.1",
     "find-up": "7.0.0",
     "globals": "15.14.0",

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -11542,7 +11542,7 @@ type TsNoUnnecessaryBooleanLiteralCompare = []|[{
 // ----- ts/no-unnecessary-condition -----
 type TsNoUnnecessaryCondition = []|[{
   
-  allowConstantLoopConditions?: boolean
+  allowConstantLoopConditions?: (boolean | ("always" | "never" | "only-allowed-literals"))
   
   allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean
   

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -5,7 +5,7 @@ import type { Linter } from 'eslint'
 export interface RuleOptions {
   /**
    * Enforce giving proper names to type parameters when there are two or more
-   * @see https://github.com/2digits-agency/configs/blob/@2digits/eslint-plugin@2.3.30/packages/eslint/src/rules/type-param-names.ts
+   * @see https://github.com/2digits-agency/configs/blob/@2digits/eslint-plugin@2.3.31/packages/eslint/src/rules/type-param-names.ts
    */
   '@2digits/type-param-names'?: Linter.RuleEntry<[]>
   /**

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -41,14 +41,14 @@
   "license": "MIT",
   "public": true,
   "dependencies": {
-    "@typescript-eslint/utils": "8.23.0",
+    "@typescript-eslint/utils": "8.24.0",
     "eslint": "9.20.0",
     "magic-regexp": "0.8.0",
     "ts-pattern": "5.6.2"
   },
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
-    "@typescript-eslint/parser": "8.23.0",
+    "@typescript-eslint/parser": "8.24.0",
     "eslint-vitest-rule-tester": "1.1.0",
     "tsup": "8.3.6",
     "typescript": "5.7.3",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -42,7 +42,7 @@
   "public": true,
   "dependencies": {
     "@typescript-eslint/utils": "8.24.0",
-    "eslint": "9.20.0",
+    "eslint": "9.20.1",
     "magic-regexp": "0.8.0",
     "ts-pattern": "5.6.2"
   },

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
-    "eslint": "9.20.0",
+    "eslint": "9.20.1",
     "prettier": "3.5.0",
     "tsup": "8.3.6",
     "typescript": "5.7.3"

--- a/packages/renovate/package.json
+++ b/packages/renovate/package.json
@@ -14,6 +14,6 @@
   "license": "MIT",
   "public": false,
   "devDependencies": {
-    "renovate": "39.164.1"
+    "renovate": "39.166.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,8 +267,8 @@ importers:
   packages/renovate:
     devDependencies:
       renovate:
-        specifier: 39.164.1
-        version: 39.164.1(encoding@0.1.13)(typanion@3.14.0)
+        specifier: 39.166.0
+        version: 39.166.0(encoding@0.1.13)(typanion@3.14.0)
 
   packages/tsconfig:
     devDependencies:
@@ -5742,8 +5742,8 @@ packages:
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
 
-  renovate@39.164.1:
-    resolution: {integrity: sha512-tTTbVe1hGL/h54JBM9uaqvxmqdkabcBWXQiblPUfRd9iVbqoa4PXfMOENFgoJ6j8GDaHXNq4pRx0ewqWkG/QKQ==}
+  renovate@39.166.0:
+    resolution: {integrity: sha512-96kgIe3Xvbv54jOwmQQtKDpH0JZM8UdGhftUkrXDs0sLQhBhxoJh+fJFyPdP18kOIGvsdhGiUCbfo+Rrf2VICA==}
     engines: {node: ^20.15.1 || ^22.11.0, pnpm: ^9.0.0}
     hasBin: true
 
@@ -5876,6 +5876,11 @@ packages:
 
   semver@7.7.0:
     resolution: {integrity: sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -9261,12 +9266,12 @@ snapshots:
 
   '@npmcli/fs@3.1.1':
     dependencies:
-      semver: 7.7.0
+      semver: 7.7.1
     optional: true
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.7.0
+      semver: 7.7.1
 
   '@octokit/auth-token@4.0.0': {}
 
@@ -9373,7 +9378,7 @@ snapshots:
       '@opentelemetry/instrumentation': 0.57.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
       forwarded-parse: 2.1.2
-      semver: 7.7.0
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9384,7 +9389,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.11.2
       require-in-the-middle: 7.4.0
-      semver: 7.7.0
+      semver: 7.7.1
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -9450,7 +9455,7 @@ snapshots:
       '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      semver: 7.7.0
+      semver: 7.7.1
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
@@ -10341,7 +10346,7 @@ snapshots:
       lodash: 4.17.21
       micromatch: 4.0.8
       p-limit: 2.3.0
-      semver: 7.7.0
+      semver: 7.7.1
       strip-ansi: 6.0.1
       tar: 6.2.1
       tinylogic: 2.0.0
@@ -10633,7 +10638,7 @@ snapshots:
 
   builtins@5.1.0:
     dependencies:
-      semver: 7.7.0
+      semver: 7.7.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -11071,7 +11076,7 @@ snapshots:
       '@one-ini/wasm': 0.1.1
       commander: 11.0.0
       minimatch: 9.0.2
-      semver: 7.7.0
+      semver: 7.7.1
 
   electron-to-chromium@1.5.32: {}
 
@@ -12009,7 +12014,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.0
+      semver: 7.7.1
       serialize-error: 7.0.1
 
   globals@11.12.0: {}
@@ -13145,7 +13150,7 @@ snapshots:
 
   node-abi@3.71.0:
     dependencies:
-      semver: 7.7.0
+      semver: 7.7.1
     optional: true
 
   node-fetch-native@1.6.4: {}
@@ -13165,7 +13170,7 @@ snapshots:
       make-fetch-happen: 13.0.1
       nopt: 7.2.1
       proc-log: 4.2.0
-      semver: 7.7.0
+      semver: 7.7.1
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -13199,7 +13204,7 @@ snapshots:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.13.1
-      semver: 7.7.0
+      semver: 7.7.1
       validate-npm-package-license: 3.0.4
 
   normalize-path@2.1.1:
@@ -13820,7 +13825,7 @@ snapshots:
 
   remove-trailing-separator@1.1.0: {}
 
-  renovate@39.164.1(encoding@0.1.13)(typanion@3.14.0):
+  renovate@39.166.0(encoding@0.1.13)(typanion@3.14.0):
     dependencies:
       '@aws-sdk/client-codecommit': 3.738.0
       '@aws-sdk/client-ec2': 3.738.0
@@ -13916,7 +13921,7 @@ snapshots:
       remark: 13.0.0
       remark-github: 10.1.0
       safe-stable-stringify: 2.5.0
-      semver: 7.7.0
+      semver: 7.7.1
       semver-stable: 3.0.0
       semver-utils: 1.1.4
       shlex: 2.1.2
@@ -14083,6 +14088,8 @@ snapshots:
   semver@7.6.3: {}
 
   semver@7.7.0: {}
+
+  semver@7.7.1: {}
 
   serialize-error@7.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 3.5.0
         version: 3.5.0
       turbo:
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: 2.4.1
+        version: 2.4.1
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -132,8 +132,8 @@ importers:
         specifier: 3.18.0
         version: 3.18.0(tailwindcss@3.4.4)
       eslint-plugin-turbo:
-        specifier: 2.4.0
-        version: 2.4.0(eslint@9.20.0(jiti@2.4.0))(turbo@2.4.0)
+        specifier: 2.4.1
+        version: 2.4.1(eslint@9.20.0(jiti@2.4.0))(turbo@2.4.1)
       eslint-plugin-unicorn:
         specifier: 56.0.1
         version: 56.0.1(eslint@9.20.0(jiti@2.4.0))
@@ -3729,8 +3729,8 @@ packages:
     peerDependencies:
       tailwindcss: ^3.4.0
 
-  eslint-plugin-turbo@2.4.0:
-    resolution: {integrity: sha512-qCgoRi/OTc1VMxab7+sdKiV1xlkY4qjK9sM+kS7+WogrB1DxLguJSQXvk4HA13SD5VmJsq+8FYOw5q4EUk6Ixg==}
+  eslint-plugin-turbo@2.4.1:
+    resolution: {integrity: sha512-sTJZrgn7G1rF7RHZcj367g2cT0+E5v0lt9LD+nBpTnCyDA/yB0PwSm/QM+aXQ39vxuK9sqlUL2LyPXyGFvUXsg==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -6294,38 +6294,38 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
-  turbo-darwin-64@2.4.0:
-    resolution: {integrity: sha512-kVMScnPUa3R4n7woNmkR15kOY0aUwCLJcUyH5UC59ggKqr5HIHwweKYK8N1pwBQso0LQF4I9i93hIzfJguCcwQ==}
+  turbo-darwin-64@2.4.1:
+    resolution: {integrity: sha512-oos3Gz5N6ol2/7+ys0wPENhl7ZzeVKIumn2BR7X2oE5dEPxNPDMOpKBwreU9ToCxM94e+uFTzKgjcUJpBqpTHA==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.4.0:
-    resolution: {integrity: sha512-8JObIpfun1guA7UlFR5jC/SOVm49lRscxMxfg5jZ5ABft79rhFC+ygN9AwAhGKv6W2DUhIh2xENkSgu4EDmUyg==}
+  turbo-darwin-arm64@2.4.1:
+    resolution: {integrity: sha512-NoIQsSSvCJDTShgX+v+doSP/g0kAhHhq5p2fpsEAlougs2wcQvwv/LndeqojzkHbxB39lOQmqBYHJcki46Q3oQ==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.4.0:
-    resolution: {integrity: sha512-xWDGGcRlBuGV7HXWAVuTY6vsQi4aZxGMAnuiuNDg8Ij1aHGohOM0RUsWMXjxz4vuJmjk9+/D6NQqHH3AJEXezg==}
+  turbo-linux-64@2.4.1:
+    resolution: {integrity: sha512-iXIeG8YhluaJF/5KQEudRf8ECBWND8X0yxXDrFIq2wmLLCg4A7gSSzVcBq30rYYeyyU4xMj/sm3HbsAaao3jjg==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.4.0:
-    resolution: {integrity: sha512-c3En99xMguc/Pdtk/rZP53LnDdw0W6lgUc04he8r8F+UHYSNvgzHh0WGXXmCC6lGbBH72kPhhGx4bAwyvi7dug==}
+  turbo-linux-arm64@2.4.1:
+    resolution: {integrity: sha512-jd5apBV7lBGn3CnkQN/hEMbwazNgZcrwLt6DIkWy/TSi5xfSQEqcR3k9HxviQ7hKMcr1Q1hN6FHWm8Vw90Ej4A==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.4.0:
-    resolution: {integrity: sha512-/gOORuOlyA8JDPzyA16CD3wvyRcuBFePa1URAnFUof9hXQmKxK0VvSDO79cYZFsJSchCKNJpckUS0gYxGsWwoA==}
+  turbo-windows-64@2.4.1:
+    resolution: {integrity: sha512-4RYRAijohyQ7uetZY4SSikSgGccq+7tmnljdm/XezpK9t0+3gldKA2vHF0++yLZeZr+CFgqmBeGSFi7B+vhc2g==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.4.0:
-    resolution: {integrity: sha512-/DJIdTFijEMM5LSiEpSfarDOMOlYqJV+EzmppqWtHqDsOLF4hbbIBH9sJR6OOp5dURAu5eURBYdmvBRz9Lo6TA==}
+  turbo-windows-arm64@2.4.1:
+    resolution: {integrity: sha512-4lZB0+AxWB01Adx5xHZhO746FgaHR0T3qzEDF2nf/nx8LAUtN3iwaZQgAsTsblaAKjiM7lxWDI0s/Q3fektsPg==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.4.0:
-    resolution: {integrity: sha512-ah/yQp2oMif1X0u7fBJ4MLMygnkbKnW5O8SG6pJvloPCpHfFoZctkSVQiJ3VnvNTq71V2JJIdwmOeu1i34OQyg==}
+  turbo@2.4.1:
+    resolution: {integrity: sha512-XIIHXAhvD3sv34WLaN/969WTHCHYmm3zf0XQ+CrEP1A7ffIQG50cwNcp7Gh96CaGyjEXMh9odoHyggoZQ3Prvw==}
     hasBin: true
 
   tweetnacl@0.13.3:
@@ -11574,11 +11574,11 @@ snapshots:
       postcss: 8.4.40
       tailwindcss: 3.4.4
 
-  eslint-plugin-turbo@2.4.0(eslint@9.20.0(jiti@2.4.0))(turbo@2.4.0):
+  eslint-plugin-turbo@2.4.1(eslint@9.20.0(jiti@2.4.0))(turbo@2.4.1):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.20.0(jiti@2.4.0)
-      turbo: 2.4.0
+      turbo: 2.4.1
 
   eslint-plugin-unicorn@56.0.1(eslint@9.20.0(jiti@2.4.0)):
     dependencies:
@@ -14580,32 +14580,32 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  turbo-darwin-64@2.4.0:
+  turbo-darwin-64@2.4.1:
     optional: true
 
-  turbo-darwin-arm64@2.4.0:
+  turbo-darwin-arm64@2.4.1:
     optional: true
 
-  turbo-linux-64@2.4.0:
+  turbo-linux-64@2.4.1:
     optional: true
 
-  turbo-linux-arm64@2.4.0:
+  turbo-linux-arm64@2.4.1:
     optional: true
 
-  turbo-windows-64@2.4.0:
+  turbo-windows-64@2.4.1:
     optional: true
 
-  turbo-windows-arm64@2.4.0:
+  turbo-windows-arm64@2.4.1:
     optional: true
 
-  turbo@2.4.0:
+  turbo@2.4.1:
     optionalDependencies:
-      turbo-darwin-64: 2.4.0
-      turbo-darwin-arm64: 2.4.0
-      turbo-linux-64: 2.4.0
-      turbo-linux-arm64: 2.4.0
-      turbo-windows-64: 2.4.0
-      turbo-windows-arm64: 2.4.0
+      turbo-darwin-64: 2.4.1
+      turbo-darwin-arm64: 2.4.1
+      turbo-linux-64: 2.4.1
+      turbo-linux-arm64: 2.4.1
+      turbo-windows-64: 2.4.1
+      turbo-windows-arm64: 2.4.1
 
   tweetnacl@0.13.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 5.66.1
         version: 5.66.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/parser':
-        specifier: 8.23.0
-        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        specifier: 8.24.0
+        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint-config-flat-gitignore:
         specifier: 2.0.0
         version: 2.0.0(eslint@9.20.0(jiti@2.4.0))
@@ -153,8 +153,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       typescript-eslint:
-        specifier: 8.23.0
-        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        specifier: 8.24.0
+        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
     devDependencies:
       '@2digits/tsconfig':
         specifier: workspace:*
@@ -169,8 +169,8 @@ importers:
         specifier: 22.13.1
         version: 22.13.1
       '@typescript-eslint/utils':
-        specifier: 8.23.0
-        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        specifier: 8.24.0
+        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint:
         specifier: 9.20.0
         version: 9.20.0(jiti@2.4.0)
@@ -187,8 +187,8 @@ importers:
   packages/eslint-plugin:
     dependencies:
       '@typescript-eslint/utils':
-        specifier: 8.23.0
-        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        specifier: 8.24.0
+        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint:
         specifier: 9.20.0
         version: 9.20.0(jiti@2.4.0)
@@ -203,8 +203,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@typescript-eslint/parser':
-        specifier: 8.23.0
-        version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        specifier: 8.24.0
+        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint-vitest-rule-tester:
         specifier: 1.1.0
         version: 1.1.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1))
@@ -2622,16 +2622,16 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.23.0':
-    resolution: {integrity: sha512-vBz65tJgRrA1Q5gWlRfvoH+w943dq9K1p1yDBY2pc+a1nbBLZp7fB9+Hk8DaALUbzjqlMfgaqlVPT1REJdkt/w==}
+  '@typescript-eslint/eslint-plugin@8.24.0':
+    resolution: {integrity: sha512-aFcXEJJCI4gUdXgoo/j9udUYIHgF23MFkg09LFz2dzEmU0+1Plk4rQWv/IYKvPHAtlkkGoB3m5e6oUp+JPsNaQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/parser@8.23.0':
-    resolution: {integrity: sha512-h2lUByouOXFAlMec2mILeELUbME5SZRN/7R9Cw2RD2lRQQY08MWMM+PmVVKKJNK1aIwqTo9t/0CvOxwPbRIE2Q==}
+  '@typescript-eslint/parser@8.24.0':
+    resolution: {integrity: sha512-MFDaO9CYiard9j9VepMNa9MTcqVvSny2N4hkY6roquzj8pdCBRENhErrteaQuu7Yjn1ppk0v1/ZF9CG3KIlrTA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2641,8 +2641,19 @@ packages:
     resolution: {integrity: sha512-OGqo7+dXHqI7Hfm+WqkZjKjsiRtFUQHPdGMXzk5mYXhJUedO7e/Y7i8AK3MyLMgZR93TX4bIzYrfyVjLC+0VSw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.24.0':
+    resolution: {integrity: sha512-HZIX0UByphEtdVBKaQBgTDdn9z16l4aTUz8e8zPQnyxwHBtf5vtl1L+OhH+m1FGV9DrRmoDuYKqzVrvWDcDozw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/type-utils@8.23.0':
     resolution: {integrity: sha512-iIuLdYpQWZKbiH+RkCGc6iu+VwscP5rCtQ1lyQ7TYuKLrcZoeJVpcLiG8DliXVkUxirW/PWlmS+d6yD51L9jvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/type-utils@8.24.0':
+    resolution: {integrity: sha512-8fitJudrnY8aq0F1wMiPM1UUgiXQRJ5i8tFjq9kGfRajU+dbPyOuHbl0qRopLEidy0MwqgTHDt6CnSeXanNIwA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2652,8 +2663,18 @@ packages:
     resolution: {integrity: sha512-1sK4ILJbCmZOTt9k4vkoulT6/y5CHJ1qUYxqpF1K/DBAd8+ZUL4LlSCxOssuH5m4rUaaN0uS0HlVPvd45zjduQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.24.0':
+    resolution: {integrity: sha512-VacJCBTyje7HGAw7xp11q439A+zeGG0p0/p2zsZwpnMzjPB5WteaWqt4g2iysgGFafrqvyLWqq6ZPZAOCoefCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.23.0':
     resolution: {integrity: sha512-LcqzfipsB8RTvH8FX24W4UUFk1bl+0yTOf9ZA08XngFwMg4Kj8A+9hwz8Cr/ZS4KwHrmo9PJiLZkOt49vPnuvQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/typescript-estree@8.24.0':
+    resolution: {integrity: sha512-ITjYcP0+8kbsvT9bysygfIfb+hBj6koDsu37JZG7xrCiy3fPJyNmfVtaGsgTUSEuTzcvME5YI5uyL5LD1EV5ZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
@@ -2665,8 +2686,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
+  '@typescript-eslint/utils@8.24.0':
+    resolution: {integrity: sha512-07rLuUBElvvEb1ICnafYWr4hk8/U7X9RDCOqd9JcAMtjh/9oRmcfN4yGzbPVirgMR0+HLVHehmu19CWeh7fsmQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
   '@typescript-eslint/visitor-keys@8.23.0':
     resolution: {integrity: sha512-oWWhcWDLwDfu++BGTZcmXWqpwtkwb5o7fxUIGksMQQDSdPW9prsSnfIOZMlsj4vBOSrcnjIUZMiIjODgGosFhQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.24.0':
+    resolution: {integrity: sha512-kArLq83QxGLbuHrTMoOEWO+l2MwsNS2TGISEdx8xgqpkbytB07XmlQyQdNDrCc1ecSqx0cnmhGvpX+VBwqqSkg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/expect@3.0.5':
@@ -6391,8 +6423,8 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
-  typescript-eslint@8.23.0:
-    resolution: {integrity: sha512-/LBRo3HrXr5LxmrdYSOCvoAMm7p2jNizNfbIpCgvG4HMsnoprRUOce/+8VJ9BDYWW68rqIENE/haVLWPeFZBVQ==}
+  typescript-eslint@8.24.0:
+    resolution: {integrity: sha512-/lmv4366en/qbB32Vz5+kCNZEMf6xYHwh1z48suBwZvAtnXKbP+YhGe8OLE2BqC67LMqKkCNLtjejdwsdW6uOQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -8749,7 +8781,7 @@ snapshots:
       '@eslint-react/eff': 1.26.2
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8767,7 +8799,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       birecord: 0.1.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8784,7 +8816,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)
       eslint-plugin-react-debug: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint-plugin-react-dom: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
@@ -8805,7 +8837,7 @@ snapshots:
       '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       ts-pattern: 5.6.2
     transitivePeerDependencies:
       - eslint
@@ -8815,7 +8847,7 @@ snapshots:
   '@eslint-react/shared@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@eslint-react/eff': 1.26.2
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       picomatch: 4.0.2
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8829,7 +8861,7 @@ snapshots:
       '@eslint-react/eff': 1.26.2
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -10051,7 +10083,7 @@ snapshots:
 
   '@tanstack/eslint-plugin-query@5.66.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)
     transitivePeerDependencies:
       - supports-color
@@ -10187,14 +10219,14 @@ snapshots:
       '@types/node': 22.13.1
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.24.0(@typescript-eslint/parser@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.23.0
+      '@typescript-eslint/parser': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.24.0
+      '@typescript-eslint/type-utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.0
       eslint: 9.20.0(jiti@2.4.0)
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -10204,12 +10236,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.23.0
+      '@typescript-eslint/scope-manager': 8.24.0
+      '@typescript-eslint/types': 8.24.0
+      '@typescript-eslint/typescript-estree': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.0
       debug: 4.4.0
       eslint: 9.20.0(jiti@2.4.0)
       typescript: 5.7.3
@@ -10220,6 +10252,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/visitor-keys': 8.23.0
+
+  '@typescript-eslint/scope-manager@8.24.0':
+    dependencies:
+      '@typescript-eslint/types': 8.24.0
+      '@typescript-eslint/visitor-keys': 8.24.0
 
   '@typescript-eslint/type-utils@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
@@ -10232,7 +10269,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      debug: 4.4.0
+      eslint: 9.20.0(jiti@2.4.0)
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.23.0': {}
+
+  '@typescript-eslint/types@8.24.0': {}
 
   '@typescript-eslint/typescript-estree@8.23.0(typescript@5.7.3)':
     dependencies:
@@ -10243,6 +10293,20 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.24.0(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.24.0
+      '@typescript-eslint/visitor-keys': 8.24.0
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
       ts-api-utils: 2.0.1(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -10259,9 +10323,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
+      '@typescript-eslint/scope-manager': 8.24.0
+      '@typescript-eslint/types': 8.24.0
+      '@typescript-eslint/typescript-estree': 8.24.0(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.0)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.23.0':
     dependencies:
       '@typescript-eslint/types': 8.23.0
+      eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.24.0':
+    dependencies:
+      '@typescript-eslint/types': 8.24.0
       eslint-visitor-keys: 4.2.0
 
   '@vitest/expect@3.0.5':
@@ -11390,7 +11470,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
@@ -11409,7 +11489,7 @@ snapshots:
       '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       compare-versions: 6.1.1
       eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
@@ -11430,7 +11510,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
@@ -11453,7 +11533,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
@@ -11472,7 +11552,7 @@ snapshots:
       '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
@@ -11492,7 +11572,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       compare-versions: 6.1.1
       eslint: 9.20.0(jiti@2.4.0)
       is-immutable-type: 5.0.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
@@ -11561,7 +11641,7 @@ snapshots:
   eslint-plugin-storybook@0.11.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
       '@storybook/csf': 0.1.11
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -11626,7 +11706,7 @@ snapshots:
     dependencies:
       '@antfu/utils': 8.1.0
       '@types/eslint': 9.6.1
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)
       vitest: 3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)
     transitivePeerDependencies:
@@ -14676,11 +14756,11 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
+  typescript-eslint@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.24.0(@typescript-eslint/parser@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)
       typescript: 5.7.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 22.13.1
         version: 22.13.1
       eslint:
-        specifier: 9.20.0
-        version: 9.20.0(jiti@2.4.0)
+        specifier: 9.20.1
+        version: 9.20.1(jiti@2.4.0)
       prettier:
         specifier: 3.5.0
         version: 3.5.0
@@ -45,8 +45,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       eslint:
-        specifier: 9.20.0
-        version: 9.20.0(jiti@2.4.0)
+        specifier: 9.20.1
+        version: 9.20.1(jiti@2.4.0)
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.0)(postcss@8.4.40)(typescript@5.7.3)(yaml@2.7.0)
@@ -64,79 +64,79 @@ importers:
         version: link:../eslint-plugin
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.4.1
-        version: 4.4.1(eslint@9.20.0(jiti@2.4.0))
+        version: 4.4.1(eslint@9.20.1(jiti@2.4.0))
       '@eslint-react/eslint-plugin':
         specifier: 1.26.2
-        version: 1.26.2(eslint@9.20.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
+        version: 1.26.2(eslint@9.20.1(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
       '@eslint/compat':
         specifier: 1.2.6
-        version: 1.2.6(eslint@9.20.0(jiti@2.4.0))
+        version: 1.2.6(eslint@9.20.1(jiti@2.4.0))
       '@eslint/js':
         specifier: 9.20.0
         version: 9.20.0
       '@graphql-eslint/eslint-plugin':
         specifier: 4.3.0
-        version: 4.3.0(@types/node@22.13.1)(encoding@0.1.13)(eslint@9.20.0(jiti@2.4.0))(graphql@16.8.2)(typescript@5.7.3)
+        version: 4.3.0(@types/node@22.13.1)(encoding@0.1.13)(eslint@9.20.1(jiti@2.4.0))(graphql@16.8.2)(typescript@5.7.3)
       '@next/eslint-plugin-next':
         specifier: 15.1.7
         version: 15.1.7
       '@tanstack/eslint-plugin-query':
         specifier: 5.66.1
-        version: 5.66.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 5.66.1(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/parser':
         specifier: 8.24.0
-        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       eslint-config-flat-gitignore:
         specifier: 2.0.0
-        version: 2.0.0(eslint@9.20.0(jiti@2.4.0))
+        version: 2.0.0(eslint@9.20.1(jiti@2.4.0))
       eslint-config-prettier:
         specifier: 10.0.1
-        version: 10.0.1(eslint@9.20.0(jiti@2.4.0))
+        version: 10.0.1(eslint@9.20.1(jiti@2.4.0))
       eslint-flat-config-utils:
         specifier: 2.0.1
         version: 2.0.1
       eslint-plugin-antfu:
         specifier: 3.0.0
-        version: 3.0.0(eslint@9.20.0(jiti@2.4.0))
+        version: 3.0.0(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-drizzle:
         specifier: 0.2.3
-        version: 0.2.3(eslint@9.20.0(jiti@2.4.0))
+        version: 0.2.3(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-jsdoc:
         specifier: 50.6.3
-        version: 50.6.3(eslint@9.20.0(jiti@2.4.0))
+        version: 50.6.3(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-jsonc:
         specifier: 2.19.1
-        version: 2.19.1(eslint@9.20.0(jiti@2.4.0))
+        version: 2.19.1(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-n:
         specifier: 17.15.1
-        version: 17.15.1(eslint@9.20.0(jiti@2.4.0))
+        version: 17.15.1(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-react:
         specifier: 7.37.4
-        version: 7.37.4(eslint@9.20.0(jiti@2.4.0))
+        version: 7.37.4(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-react-compiler:
         specifier: 19.0.0-beta-e552027-20250112
-        version: 19.0.0-beta-e552027-20250112(eslint@9.20.0(jiti@2.4.0))
+        version: 19.0.0-beta-e552027-20250112(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-react-hooks:
         specifier: 5.1.0
-        version: 5.1.0(eslint@9.20.0(jiti@2.4.0))
+        version: 5.1.0(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-regexp:
         specifier: 2.7.0
-        version: 2.7.0(eslint@9.20.0(jiti@2.4.0))
+        version: 2.7.0(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-sonarjs:
         specifier: 3.0.1
-        version: 3.0.1(eslint@9.20.0(jiti@2.4.0))
+        version: 3.0.1(eslint@9.20.1(jiti@2.4.0))
       eslint-plugin-storybook:
         specifier: 0.11.2
-        version: 0.11.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 0.11.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       eslint-plugin-tailwindcss:
         specifier: 3.18.0
         version: 3.18.0(tailwindcss@3.4.4)
       eslint-plugin-turbo:
         specifier: 2.4.1
-        version: 2.4.1(eslint@9.20.0(jiti@2.4.0))(turbo@2.4.1)
+        version: 2.4.1(eslint@9.20.1(jiti@2.4.0))(turbo@2.4.1)
       eslint-plugin-unicorn:
         specifier: 56.0.1
-        version: 56.0.1(eslint@9.20.0(jiti@2.4.0))
+        version: 56.0.1(eslint@9.20.1(jiti@2.4.0))
       find-up:
         specifier: 7.0.0
         version: 7.0.0
@@ -154,14 +154,14 @@ importers:
         version: 1.0.0
       typescript-eslint:
         specifier: 8.24.0
-        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
     devDependencies:
       '@2digits/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       '@eslint/config-inspector':
         specifier: 1.0.0
-        version: 1.0.0(eslint@9.20.0(jiti@2.4.0))
+        version: 1.0.0(eslint@9.20.1(jiti@2.4.0))
       '@types/eslint__js':
         specifier: 8.42.3
         version: 8.42.3
@@ -170,13 +170,13 @@ importers:
         version: 22.13.1
       '@typescript-eslint/utils':
         specifier: 8.24.0
-        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       eslint:
-        specifier: 9.20.0
-        version: 9.20.0(jiti@2.4.0)
+        specifier: 9.20.1
+        version: 9.20.1(jiti@2.4.0)
       eslint-typegen:
         specifier: 1.0.0
-        version: 1.0.0(eslint@9.20.0(jiti@2.4.0))
+        version: 1.0.0(eslint@9.20.1(jiti@2.4.0))
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.0)(postcss@8.4.40)(typescript@5.7.3)(yaml@2.7.0)
@@ -188,10 +188,10 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: 8.24.0
-        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       eslint:
-        specifier: 9.20.0
-        version: 9.20.0(jiti@2.4.0)
+        specifier: 9.20.1
+        version: 9.20.1(jiti@2.4.0)
       magic-regexp:
         specifier: 0.8.0
         version: 0.8.0
@@ -204,10 +204,10 @@ importers:
         version: link:../tsconfig
       '@typescript-eslint/parser':
         specifier: 8.24.0
-        version: 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        version: 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       eslint-vitest-rule-tester:
         specifier: 1.1.0
-        version: 1.1.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1))
+        version: 1.1.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1))
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.0)(postcss@8.4.40)(typescript@5.7.3)(yaml@2.7.0)
@@ -252,8 +252,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       eslint:
-        specifier: 9.20.0
-        version: 9.20.0(jiti@2.4.0)
+        specifier: 9.20.1
+        version: 9.20.1(jiti@2.4.0)
       prettier:
         specifier: 3.5.0
         version: 3.5.0
@@ -3804,8 +3804,8 @@ packages:
       eslint: ^9.0.0
       vitest: ^1.0.0 || ^2.0.0 || ^3.0.0
 
-  eslint@9.20.0:
-    resolution: {integrity: sha512-aL4F8167Hg4IvsW89ejnpTwx+B/UQRzJPGgbIOl+4XqffWsahVVsLEWoZvnrVuwpWmnRd7XeXmQI1zlKcFDteA==}
+  eslint@9.20.1:
+    resolution: {integrity: sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -7649,11 +7649,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.25.9(@babel/core@7.26.0)(eslint@9.20.0(jiti@2.4.0))':
+  '@babel/eslint-parser@7.25.9(@babel/core@7.26.0)(eslint@9.20.1(jiti@2.4.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -8763,25 +8763,25 @@ snapshots:
   '@esbuild/win32-x64@0.24.2':
     optional: true
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.4.1(eslint@9.20.0(jiti@2.4.0))':
+  '@eslint-community/eslint-plugin-eslint-comments@4.4.1(eslint@9.20.1(jiti@2.4.0))':
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       ignore: 5.3.1
 
-  '@eslint-community/eslint-utils@4.4.1(eslint@9.20.0(jiti@2.4.0))':
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.20.1(jiti@2.4.0))':
     dependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint-react/ast@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/ast@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@eslint-react/eff': 1.26.2
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8789,17 +8789,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/core@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/core@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       birecord: 0.1.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8809,45 +8809,45 @@ snapshots:
 
   '@eslint-react/eff@1.26.2': {}
 
-  '@eslint-react/eslint-plugin@1.26.2(eslint@9.20.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)':
+  '@eslint-react/eslint-plugin@1.26.2(eslint@9.20.1(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
-      eslint-plugin-react-debug: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-dom: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-hooks-extra: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-naming-convention: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-web-api: 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint-plugin-react-x: 1.26.2(eslint@9.20.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
+      eslint-plugin-react-debug: 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-dom: 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-hooks-extra: 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-naming-convention: 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-web-api: 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint-plugin-react-x: 1.26.2(eslint@9.20.1(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
       - ts-api-utils
 
-  '@eslint-react/jsx@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/jsx@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       ts-pattern: 5.6.2
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
 
-  '@eslint-react/shared@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/shared@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@eslint-react/eff': 1.26.2
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       picomatch: 4.0.2
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8855,13 +8855,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/var@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@eslint-react/var@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -8869,9 +8869,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint/compat@1.2.6(eslint@9.20.0(jiti@2.4.0))':
+  '@eslint/compat@1.2.6(eslint@9.20.1(jiti@2.4.0))':
     optionalDependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
 
   '@eslint/config-array@0.19.0':
     dependencies:
@@ -8881,7 +8881,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-inspector@1.0.0(eslint@9.20.0(jiti@2.4.0))':
+  '@eslint/config-inspector@1.0.0(eslint@9.20.1(jiti@2.4.0))':
     dependencies:
       '@nodelib/fs.walk': 3.0.1
       bundle-require: 5.1.0(esbuild@0.24.2)
@@ -8889,7 +8889,7 @@ snapshots:
       chokidar: 4.0.3
       debug: 4.4.0
       esbuild: 0.24.2
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       fast-glob: 3.3.3
       find-up: 7.0.0
       get-port-please: 3.1.2
@@ -8935,13 +8935,13 @@ snapshots:
       '@eslint/core': 0.10.0
       levn: 0.4.1
 
-  '@graphql-eslint/eslint-plugin@4.3.0(@types/node@22.13.1)(encoding@0.1.13)(eslint@9.20.0(jiti@2.4.0))(graphql@16.8.2)(typescript@5.7.3)':
+  '@graphql-eslint/eslint-plugin@4.3.0(@types/node@22.13.1)(encoding@0.1.13)(eslint@9.20.1(jiti@2.4.0))(graphql@16.8.2)(typescript@5.7.3)':
     dependencies:
       '@graphql-tools/code-file-loader': 8.1.6(graphql@16.8.2)
       '@graphql-tools/graphql-tag-pluck': 8.3.5(graphql@16.8.2)
       '@graphql-tools/utils': 10.6.0(graphql@16.8.2)
       debug: 4.3.7
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       fast-glob: 3.3.2
       graphql: 16.8.2
       graphql-config: 5.1.3(@types/node@22.13.1)(encoding@0.1.13)(graphql@16.8.2)(typescript@5.7.3)
@@ -10081,10 +10081,10 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/eslint-plugin-query@5.66.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@tanstack/eslint-plugin-query@5.66.1(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10219,15 +10219,15 @@ snapshots:
       '@types/node': 22.13.1
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.24.0(@typescript-eslint/parser@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.24.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.24.0
-      '@typescript-eslint/type-utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.0
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -10236,14 +10236,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.24.0
       '@typescript-eslint/types': 8.24.0
       '@typescript-eslint/typescript-estree': 8.24.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.0
       debug: 4.4.0
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -10258,23 +10258,23 @@ snapshots:
       '@typescript-eslint/types': 8.24.0
       '@typescript-eslint/visitor-keys': 8.24.0
 
-  '@typescript-eslint/type-utils@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       debug: 4.4.0
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       ts-api-utils: 2.0.1(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.24.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       debug: 4.4.0
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       ts-api-utils: 2.0.1(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -10312,24 +10312,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.4.0))
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.4.0))
       '@typescript-eslint/scope-manager': 8.24.0
       '@typescript-eslint/types': 8.24.0
       '@typescript-eslint/typescript-estree': 8.24.0(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -11360,58 +11360,58 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@9.20.0(jiti@2.4.0)):
+  eslint-compat-utils@0.5.1(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       semver: 7.7.0
 
-  eslint-compat-utils@0.6.4(eslint@9.20.0(jiti@2.4.0)):
+  eslint-compat-utils@0.6.4(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       semver: 7.6.3
 
-  eslint-config-flat-gitignore@2.0.0(eslint@9.20.0(jiti@2.4.0)):
+  eslint-config-flat-gitignore@2.0.0(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      '@eslint/compat': 1.2.6(eslint@9.20.0(jiti@2.4.0))
-      eslint: 9.20.0(jiti@2.4.0)
+      '@eslint/compat': 1.2.6(eslint@9.20.1(jiti@2.4.0))
+      eslint: 9.20.1(jiti@2.4.0)
 
-  eslint-config-prettier@10.0.1(eslint@9.20.0(jiti@2.4.0)):
+  eslint-config-prettier@10.0.1(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
 
   eslint-flat-config-utils@2.0.1:
     dependencies:
       pathe: 2.0.2
 
-  eslint-json-compat-utils@0.2.1(eslint@9.20.0(jiti@2.4.0))(jsonc-eslint-parser@2.4.0):
+  eslint-json-compat-utils@0.2.1(eslint@9.20.1(jiti@2.4.0))(jsonc-eslint-parser@2.4.0):
     dependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       esquery: 1.6.0
       jsonc-eslint-parser: 2.4.0
 
-  eslint-plugin-antfu@3.0.0(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-antfu@3.0.0(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
 
-  eslint-plugin-drizzle@0.2.3(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-drizzle@0.2.3(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
 
-  eslint-plugin-es-x@7.8.0(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-es-x@7.8.0(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.4.0))
       '@eslint-community/regexpp': 4.12.1
-      eslint: 9.20.0(jiti@2.4.0)
-      eslint-compat-utils: 0.5.1(eslint@9.20.0(jiti@2.4.0))
+      eslint: 9.20.1(jiti@2.4.0)
+      eslint-compat-utils: 0.5.1(eslint@9.20.1(jiti@2.4.0))
 
-  eslint-plugin-jsdoc@50.6.3(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-jsdoc@50.6.3(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
       '@es-joy/jsdoccomment': 0.49.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
       debug: 4.4.0
       escape-string-regexp: 4.0.0
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       espree: 10.3.0
       esquery: 1.6.0
       parse-imports: 2.1.1
@@ -11421,12 +11421,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsonc@2.19.1(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-jsonc@2.19.1(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
-      eslint: 9.20.0(jiti@2.4.0)
-      eslint-compat-utils: 0.6.4(eslint@9.20.0(jiti@2.4.0))
-      eslint-json-compat-utils: 0.2.1(eslint@9.20.0(jiti@2.4.0))(jsonc-eslint-parser@2.4.0)
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.4.0))
+      eslint: 9.20.1(jiti@2.4.0)
+      eslint-compat-utils: 0.6.4(eslint@9.20.1(jiti@2.4.0))
+      eslint-json-compat-utils: 0.2.1(eslint@9.20.1(jiti@2.4.0))(jsonc-eslint-parser@2.4.0)
       espree: 9.6.1
       graphemer: 1.4.0
       jsonc-eslint-parser: 2.4.0
@@ -11435,43 +11435,43 @@ snapshots:
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-n@17.15.1(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-n@17.15.1(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.4.0))
       enhanced-resolve: 5.17.1
-      eslint: 9.20.0(jiti@2.4.0)
-      eslint-plugin-es-x: 7.8.0(eslint@9.20.0(jiti@2.4.0))
+      eslint: 9.20.1(jiti@2.4.0)
+      eslint-plugin-es-x: 7.8.0(eslint@9.20.1(jiti@2.4.0))
       get-tsconfig: 4.8.1
       globals: 15.14.0
       ignore: 5.3.2
       minimatch: 9.0.5
       semver: 7.6.3
 
-  eslint-plugin-react-compiler@19.0.0-beta-e552027-20250112(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-react-compiler@19.0.0-beta-e552027-20250112(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
       '@babel/core': 7.24.6
       '@babel/parser': 7.26.2
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.24.6)
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       hermes-parser: 0.25.1
       zod: 3.24.1
       zod-validation-error: 3.3.0(zod@3.24.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-debug@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-debug@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11479,19 +11479,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-dom@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-dom@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       compare-versions: 6.1.1
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11499,19 +11499,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks-extra@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-hooks-extra@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11519,22 +11519,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@5.1.0(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-react-hooks@5.1.0(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
 
-  eslint-plugin-react-naming-convention@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-naming-convention@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11542,18 +11542,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-web-api@1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-react-web-api@1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11561,21 +11561,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@1.26.2(eslint@9.20.0(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3):
+  eslint-plugin-react-x@1.26.2(eslint@9.20.1(jiti@2.4.0))(ts-api-utils@2.0.1(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/core': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/ast': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/core': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@eslint-react/eff': 1.26.2
-      '@eslint-react/jsx': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/shared': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@eslint-react/var': 1.26.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/jsx': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/shared': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@eslint-react/var': 1.26.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       compare-versions: 6.1.1
-      eslint: 9.20.0(jiti@2.4.0)
-      is-immutable-type: 5.0.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
+      is-immutable-type: 5.0.1(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     optionalDependencies:
@@ -11584,7 +11584,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.4(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-react@7.37.4(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
@@ -11592,7 +11592,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -11606,21 +11606,21 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-regexp@2.7.0(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-regexp@2.7.0(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.4.0))
       '@eslint-community/regexpp': 4.12.1
       comment-parser: 1.4.1
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       jsdoc-type-pratt-parser: 4.1.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-sonarjs@3.0.1(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-sonarjs@3.0.1(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/eslint-parser': 7.25.9(@babel/core@7.26.0)(eslint@9.20.0(jiti@2.4.0))
+      '@babel/eslint-parser': 7.25.9(@babel/core@7.26.0)(eslint@9.20.1(jiti@2.4.0))
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/preset-flow': 7.25.9(@babel/core@7.26.0)
@@ -11628,7 +11628,7 @@ snapshots:
       '@eslint-community/regexpp': 4.12.1
       builtin-modules: 3.3.0
       bytes: 3.1.2
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       functional-red-black-tree: 1.0.1
       jsx-ast-utils: 3.3.5
       minimatch: 9.0.5
@@ -11638,11 +11638,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-storybook@0.11.2(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
+  eslint-plugin-storybook@0.11.2(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
       '@storybook/csf': 0.1.11
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -11654,20 +11654,20 @@ snapshots:
       postcss: 8.4.40
       tailwindcss: 3.4.4
 
-  eslint-plugin-turbo@2.4.1(eslint@9.20.0(jiti@2.4.0))(turbo@2.4.1):
+  eslint-plugin-turbo@2.4.1(eslint@9.20.1(jiti@2.4.0))(turbo@2.4.1):
     dependencies:
       dotenv: 16.0.3
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       turbo: 2.4.1
 
-  eslint-plugin-unicorn@56.0.1(eslint@9.20.0(jiti@2.4.0)):
+  eslint-plugin-unicorn@56.0.1(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.4.0))
       ci-info: 4.0.0
       clean-regexp: 1.0.0
       core-js-compat: 3.38.1
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       esquery: 1.6.0
       globals: 15.14.0
       indent-string: 4.0.0
@@ -11690,9 +11690,9 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-typegen@1.0.0(eslint@9.20.0(jiti@2.4.0)):
+  eslint-typegen@1.0.0(eslint@9.20.1(jiti@2.4.0)):
     dependencies:
-      eslint: 9.20.0(jiti@2.4.0)
+      eslint: 9.20.1(jiti@2.4.0)
       json-schema-to-typescript-lite: 14.1.0
       ohash: 1.1.4
 
@@ -11702,20 +11702,20 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint-vitest-rule-tester@1.1.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)):
+  eslint-vitest-rule-tester@1.1.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)):
     dependencies:
       '@antfu/utils': 8.1.0
       '@types/eslint': 9.6.1
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
       vitest: 3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint@9.20.0(jiti@2.4.0):
+  eslint@9.20.1(jiti@2.4.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.0))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.4.0))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.19.0
       '@eslint/core': 0.11.0
@@ -12451,10 +12451,10 @@ snapshots:
 
   is-hexadecimal@1.0.4: {}
 
-  is-immutable-type@5.0.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
+  is-immutable-type@5.0.1(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
       ts-api-utils: 2.0.1(typescript@5.7.3)
       ts-declaration-location: 1.0.4(typescript@5.7.3)
       typescript: 5.7.3
@@ -14756,12 +14756,12 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3):
+  typescript-eslint@8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.24.0(@typescript-eslint/parser@8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
-      eslint: 9.20.0(jiti@2.4.0)
+      '@typescript-eslint/eslint-plugin': 8.24.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.0))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0(@types/node@22.13.1)(encoding@0.1.13)(eslint@9.20.0(jiti@2.4.0))(graphql@16.8.2)(typescript@5.7.3)
       '@next/eslint-plugin-next':
-        specifier: 15.1.6
-        version: 15.1.6
+        specifier: 15.1.7
+        version: 15.1.7
       '@tanstack/eslint-plugin-query':
         specifier: 5.66.0
         version: 5.66.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
@@ -1808,8 +1808,8 @@ packages:
     resolution: {integrity: sha512-SkAyKAByB9l93Slyg8AUHGuM2kjvWioUTCckT/03J09jYnfEzMO/wSXmEhnKGYs6qx9De8TH4yJCl0Y9lRgnyQ==}
     engines: {node: '>=14.18.0'}
 
-  '@next/eslint-plugin-next@15.1.6':
-    resolution: {integrity: sha512-+slMxhTgILUntZDGNgsKEYHUvpn72WP1YTlkmEhS51vnVd7S9jEEy0n9YAMcI21vUG4akTw9voWH02lrClt/yw==}
+  '@next/eslint-plugin-next@15.1.7':
+    resolution: {integrity: sha512-kRP7RjSxfTO13NE317ek3mSGzoZlI33nc/i5hs1KaWpK+egs85xg0DJ4p32QEiHnR0mVjuUfhRIun7awqfL7pQ==}
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
@@ -9221,7 +9221,7 @@ snapshots:
       jju: 1.4.0
       read-yaml-file: 1.1.0
 
-  '@next/eslint-plugin-next@15.1.6':
+  '@next/eslint-plugin-next@15.1.7':
     dependencies:
       fast-glob: 3.3.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: 15.1.7
         version: 15.1.7
       '@tanstack/eslint-plugin-query':
-        specifier: 5.66.0
-        version: 5.66.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
+        specifier: 5.66.1
+        version: 5.66.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       '@typescript-eslint/parser':
         specifier: 8.23.0
         version: 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
@@ -2497,8 +2497,8 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
-  '@tanstack/eslint-plugin-query@5.66.0':
-    resolution: {integrity: sha512-CzZhBxicLDuuSJbkZ4nPcuBqWnhLu72Zt9p/7qLQ93BepVnZJV6ZDlBLBuN5eg7YRACwECPLsntnwo1zuhgseQ==}
+  '@tanstack/eslint-plugin-query@5.66.1':
+    resolution: {integrity: sha512-pYMVTGgJ7yPk9Rm6UWEmbY6TX0EmMmxJqYkthgeDCwEznToy2m+W928nUODFirtZBZlhBsqHy33LO0kyTlgf0w==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
@@ -10049,7 +10049,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/eslint-plugin-query@5.66.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
+  '@tanstack/eslint-plugin-query@5.66.1(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.0))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.0)


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated Node.js, pnpm, and various development dependencies across the monorepo, with focus on ESLint ecosystem updates and version pinning for consistent environments.

- Updated Node.js to 22.14.0 and pnpm to 10.3.0 in `mise.toml`, adding version pinning with `pin=true`
- Upgraded typescript-eslint packages from 8.23.0 to 8.24.0 across multiple packages
- Updated ESLint from 9.20.0 to 9.20.1 throughout the monorepo
- Bumped Renovate from 39.164.1 to 39.166.0 in `packages/renovate/package.json`



<!-- /greptile_comment -->