### PR TITLE
feat: add GLOB_SRC to eslint config files

### DIFF
--- a/packages/eslint-config/src/configs/antfu.ts
+++ b/packages/eslint-config/src/configs/antfu.ts
@@ -1,10 +1,12 @@
 import pluginAntfu from 'eslint-plugin-antfu';
 
+import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
 export function antfu(): TypedFlatConfigItem[] {
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:antfu',
       plugins: {
         antfu: pluginAntfu,

--- a/packages/eslint-config/src/configs/boolean.ts
+++ b/packages/eslint-config/src/configs/boolean.ts
@@ -1,10 +1,12 @@
 import pluginDeMorgan from 'eslint-plugin-de-morgan';
 
+import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
 export function boolean(): TypedFlatConfigItem[] {
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:boolean',
       plugins: {
         boolean: pluginDeMorgan,

--- a/packages/eslint-config/src/configs/comments.ts
+++ b/packages/eslint-config/src/configs/comments.ts
@@ -3,6 +3,7 @@ import configs from '@eslint-community/eslint-plugin-eslint-comments/configs';
 import { renamePluginsInRules } from 'eslint-flat-config-utils';
 
 import { PluginNameMap } from '../constants';
+import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
 const recommended = renamePluginsInRules(configs.recommended.rules as never, PluginNameMap);
@@ -10,6 +11,7 @@ const recommended = renamePluginsInRules(configs.recommended.rules as never, Plu
 export function comments(): TypedFlatConfigItem[] {
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:comments',
       plugins: {
         comments: pluginComments,

--- a/packages/eslint-config/src/configs/drizzle.ts
+++ b/packages/eslint-config/src/configs/drizzle.ts
@@ -1,5 +1,6 @@
 import { fixupPluginRules } from '@eslint/compat';
 
+import { GLOB_SRC } from '../globs';
 import type { OptionsWithDrizzle, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
@@ -10,6 +11,7 @@ export async function drizzle(options: OptionsWithDrizzle = {}): Promise<TypedFl
 
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:drizzle',
       plugins: {
         drizzle: fixupPluginRules(drizzle as never),

--- a/packages/eslint-config/src/configs/javascript.ts
+++ b/packages/eslint-config/src/configs/javascript.ts
@@ -1,6 +1,7 @@
 import eslint from '@eslint/js';
 import globals from 'globals';
 
+import { GLOB_SRC } from '../globs';
 import type { OptionsOverrides, TypedFlatConfigItem } from '../types';
 
 export function javascript(options: OptionsOverrides = {}): TypedFlatConfigItem[] {
@@ -8,6 +9,7 @@ export function javascript(options: OptionsOverrides = {}): TypedFlatConfigItem[
 
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:javascript',
       languageOptions: {
         ecmaVersion: 2022,

--- a/packages/eslint-config/src/configs/jsdoc.ts
+++ b/packages/eslint-config/src/configs/jsdoc.ts
@@ -1,9 +1,11 @@
+import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
 export async function jsdoc(): Promise<TypedFlatConfigItem[]> {
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:jsdoc',
       plugins: {
         jsdoc: await interopDefault(import('eslint-plugin-jsdoc')),

--- a/packages/eslint-config/src/configs/node.ts
+++ b/packages/eslint-config/src/configs/node.ts
@@ -1,9 +1,11 @@
+import { GLOB_SRC } from '../globs';
 import { pluginNode } from '../plugins';
 import type { TypedFlatConfigItem } from '../types';
 
 export function node(): TypedFlatConfigItem[] {
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:node',
       settings: {
         node: {

--- a/packages/eslint-config/src/configs/regexp.ts
+++ b/packages/eslint-config/src/configs/regexp.ts
@@ -1,10 +1,12 @@
 import pluginRegexp from 'eslint-plugin-regexp';
 
+import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
 export function regexp(): TypedFlatConfigItem[] {
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:regexp',
       plugins: {
         regexp: pluginRegexp,

--- a/packages/eslint-config/src/configs/sonar.ts
+++ b/packages/eslint-config/src/configs/sonar.ts
@@ -1,9 +1,11 @@
+import { GLOB_SRC } from '../globs';
 import { pluginSonar } from '../plugins';
 import type { TypedFlatConfigItem } from '../types';
 
 export function sonar(): TypedFlatConfigItem[] {
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:sonar',
       plugins: {
         sonar: pluginSonar,

--- a/packages/eslint-config/src/configs/tailwind.ts
+++ b/packages/eslint-config/src/configs/tailwind.ts
@@ -1,5 +1,6 @@
 import { findUp } from 'find-up';
 
+import { GLOB_SRC } from '../globs';
 import type { OptionsOverrides, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
@@ -14,6 +15,7 @@ export async function tailwind(options: OptionsOverrides = {}): Promise<TypedFla
 
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:tailwind',
       plugins: {
         tailwindcss,

--- a/packages/eslint-config/src/configs/tanstack.ts
+++ b/packages/eslint-config/src/configs/tanstack.ts
@@ -1,6 +1,7 @@
 import { renamePluginsInRules } from 'eslint-flat-config-utils';
 
 import { PluginNameMap } from '../constants';
+import { GLOB_SRC } from '../globs';
 import type { OptionsOverrides, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
@@ -13,6 +14,7 @@ export async function tanstack(options: OptionsOverrides = {}): Promise<TypedFla
 
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:tanstack',
       plugins: { tanstack },
       rules: {

--- a/packages/eslint-config/src/configs/turbo.ts
+++ b/packages/eslint-config/src/configs/turbo.ts
@@ -1,3 +1,4 @@
+import { GLOB_SRC } from '../globs';
 import type { OptionsOverrides, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
@@ -8,6 +9,7 @@ export async function turbo(options: OptionsOverrides = {}): Promise<TypedFlatCo
 
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:turbo',
       plugins: {
         turbo,

--- a/packages/eslint-config/src/configs/unicorn.ts
+++ b/packages/eslint-config/src/configs/unicorn.ts
@@ -1,15 +1,17 @@
+import { GLOB_SRC } from '../globs';
 import { pluginUnicorn } from '../plugins';
 import type { TypedFlatConfigItem } from '../types';
 
 export function unicorn(): TypedFlatConfigItem[] {
   return [
     {
+      files: [GLOB_SRC],
       name: '2digits:unicorn',
       plugins: {
         unicorn: pluginUnicorn,
       },
       rules: {
-        ...pluginUnicorn.configs['flat/recommended'].rules,
+        ...pluginUnicorn.configs.recommended.rules,
 
         'unicorn/filename-case': ['off'],
         'unicorn/prefer-module': ['off'],


### PR DESCRIPTION
Added source file glob pattern to all ESLint config rules to properly scope their application. This ensures the rules only apply to source files and not configuration or build files.

The change also fixes the unicorn plugin configuration to use the standard recommended ruleset instead of the flat/recommended variant.

<!-- greptile_comment -->

## Greptile Summary

Added GLOB_SRC pattern across all ESLint configuration files to properly scope rule application to source files only, preventing rules from affecting configuration and build files.

- Added `files: [GLOB_SRC]` to all ESLint config files in `/packages/eslint-config/src/configs/`
- Changed unicorn plugin from `flat/recommended` to `recommended` ruleset in `/packages/eslint-config/src/configs/unicorn.ts`
- Set Node.js version requirement to `>= 22.0.0` in `/packages/eslint-config/src/configs/node.ts`, which may need review
- Maintained existing rule configurations and functionality while adding proper file scoping



<!-- /greptile_comment -->