### PR TITLE
Added @eslint/css and css-tree types

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,19 +3,28 @@ import { fileURLToPath } from 'node:url';
 
 import twoDigits from '@2digits/eslint-config';
 
-export default twoDigits({
-  ignores: {
-    gitIgnore: {
-      cwd: path.dirname(fileURLToPath(import.meta.url)),
+export default twoDigits(
+  {
+    ignores: {
+      gitIgnore: {
+        cwd: path.dirname(fileURLToPath(import.meta.url)),
+      },
+    },
+    react: true,
+    next: true,
+    tailwind: true,
+    storybook: true,
+    graphql: true,
+    tanstack: true,
+    turbo: true,
+    drizzle: true,
+    ts: true,
+  },
+  {
+    files: ['packages/eslint-config/typings/css-tree/index.d.ts'],
+    rules: {
+      '@2digits/type-param-names': 'off',
+      'ts/no-explicit-any': 'off',
     },
   },
-  react: true,
-  next: true,
-  tailwind: true,
-  storybook: true,
-  graphql: true,
-  tanstack: true,
-  turbo: true,
-  drizzle: true,
-  ts: true,
-});
+);

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -42,6 +42,7 @@
     "@eslint-community/eslint-plugin-eslint-comments": "4.4.1",
     "@eslint-react/eslint-plugin": "1.26.2",
     "@eslint/compat": "1.2.6",
+    "@eslint/css": "0.4.0",
     "@eslint/js": "9.20.0",
     "@graphql-eslint/eslint-plugin": "4.3.0",
     "@next/eslint-plugin-next": "15.1.7",

--- a/packages/eslint-config/typings/css-tree/index.d.ts
+++ b/packages/eslint-config/typings/css-tree/index.d.ts
@@ -1,0 +1,966 @@
+declare module 'css-tree' {
+  export interface CssLocation {
+    source: string;
+    start: {
+      offset: number;
+      line: number;
+      column: number;
+    };
+    end: {
+      offset: number;
+      line: number;
+      column: number;
+    };
+  }
+
+  export interface ListItem<TData> {
+    prev: ListItem<TData> | null;
+    next: ListItem<TData> | null;
+    data: TData;
+  }
+
+  export type IteratorFn<TData, TResult, TContext = List<TData>> = (
+    this: TContext,
+    item: TData,
+    node: ListItem<TData>,
+    list: List<TData>,
+  ) => TResult;
+  export type FilterFn<TData, TResult extends TData, TContext = List<TData>> = (
+    this: TContext,
+    item: TData,
+    node: ListItem<TData>,
+    list: List<TData>,
+  ) => item is TResult;
+  export type ReduceFn<TData, TValue, TContext = List<TData>> = (this: TContext, accum: TValue, data: TData) => TValue;
+
+  export class List<TData> {
+    constructor();
+    get size(): number;
+    get isEmpty(): boolean;
+    get first(): TData | null;
+    get last(): TData | null;
+    [Symbol.iterator](): IterableIterator<TData>;
+    fromArray(array: TData[]): List<TData>;
+    createItem(data: TData): ListItem<TData>;
+    toArray(): TData[];
+    toJSON(): TData[];
+    forEach<TContext>(fn: IteratorFn<TData, void, TContext>, context: TContext): void;
+    forEach(fn: IteratorFn<TData, void>): void;
+    forEachRight<TContext>(fn: IteratorFn<TData, void, TContext>, context: TContext): void;
+    forEachRight(fn: IteratorFn<TData, void>): void;
+    nextUntil<TContext>(start: ListItem<TData>, fn: IteratorFn<TData, boolean, TContext>, context: TContext): void;
+    nextUntil(start: ListItem<TData>, fn: IteratorFn<TData, boolean>): void;
+    prevUntil<TContext>(start: ListItem<TData>, fn: IteratorFn<TData, boolean, TContext>, context: TContext): void;
+    prevUntil(start: ListItem<TData>, fn: IteratorFn<TData, boolean>): void;
+    reduce<TValue, TContext>(fn: ReduceFn<TData, TValue, TContext>, initialValue: TValue, context: TContext): TValue;
+    reduce<TValue>(fn: ReduceFn<TData, TValue>, initialValue: TValue): TValue;
+    reduceRight<TValue, TContext>(
+      fn: ReduceFn<TData, TValue, TContext>,
+      initialValue: TValue,
+      context: TContext,
+    ): TValue;
+    reduceRight<TValue>(fn: ReduceFn<TData, TValue>, initialValue: TValue): TValue;
+    some<TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): boolean;
+    some(fn: IteratorFn<TData, boolean>): boolean;
+    map<TContext, TResult>(fn: IteratorFn<TData, TResult, TContext>, context: TContext): List<TResult>;
+    map<TResult>(fn: IteratorFn<TData, TResult>): List<TResult>;
+    filter<TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>;
+    filter<TResult extends TData>(fn: FilterFn<TData, TResult>): List<TResult>;
+    filter<TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>;
+    filter(fn: IteratorFn<TData, boolean>): List<TData>;
+    clear(): void;
+    copy(): List<TData>;
+    prepend(item: ListItem<TData>): List<TData>;
+    prependData(data: TData): List<TData>;
+    append(item: ListItem<TData>): List<TData>;
+    appendData(data: TData): List<TData>;
+    insert(item: ListItem<TData>, before: ListItem<TData>): List<TData>;
+    insertData(data: TData, before: ListItem<TData>): List<TData>;
+    remove(item: ListItem<TData>): ListItem<TData>;
+    push(item: TData): void;
+    pop(): ListItem<TData> | undefined;
+    unshift(data: TData): void;
+    shift(): ListItem<TData> | undefined;
+    prependList(list: List<TData>): List<TData>;
+    appendList(list: List<TData>): List<TData>;
+    insertList(list: List<TData>, before: ListItem<TData>): List<TData>;
+    replace(oldItem: ListItem<TData>, newItemOrList: List<TData> | ListItem<TData>): List<TData>;
+  }
+
+  export interface CssNodeCommon {
+    type: string;
+    loc?: CssLocation | undefined;
+  }
+
+  export interface AnPlusB extends CssNodeCommon {
+    type: 'AnPlusB';
+    a: string | null;
+    b: string | null;
+  }
+
+  export interface Atrule extends CssNodeCommon {
+    type: 'Atrule';
+    name: string;
+    prelude: AtrulePrelude | Raw | null;
+    block: Block | null;
+  }
+
+  export interface AtrulePlain extends CssNodeCommon {
+    type: 'Atrule';
+    name: string;
+    prelude: AtrulePreludePlain | Raw | null;
+    block: BlockPlain | null;
+  }
+
+  export interface AtrulePrelude extends CssNodeCommon {
+    type: 'AtrulePrelude';
+    children: List<CssNode>;
+  }
+
+  export interface AtrulePreludePlain extends CssNodeCommon {
+    type: 'AtrulePrelude';
+    children: CssNodePlain[];
+  }
+
+  export interface AttributeSelector extends CssNodeCommon {
+    type: 'AttributeSelector';
+    name: Identifier;
+    matcher: string | null;
+    value: StringNode | Identifier | null;
+    flags: string | null;
+  }
+
+  export interface Block extends CssNodeCommon {
+    type: 'Block';
+    children: List<CssNode>;
+  }
+
+  export interface BlockPlain extends CssNodeCommon {
+    type: 'Block';
+    children: CssNodePlain[];
+  }
+
+  export interface Brackets extends CssNodeCommon {
+    type: 'Brackets';
+    children: List<CssNode>;
+  }
+
+  export interface BracketsPlain extends CssNodeCommon {
+    type: 'Brackets';
+    children: CssNodePlain[];
+  }
+
+  export interface CDC extends CssNodeCommon {
+    type: 'CDC';
+  }
+
+  export interface CDO extends CssNodeCommon {
+    type: 'CDO';
+  }
+
+  export interface ClassSelector extends CssNodeCommon {
+    type: 'ClassSelector';
+    name: string;
+  }
+
+  export interface Combinator extends CssNodeCommon {
+    type: 'Combinator';
+    name: string;
+  }
+
+  export interface Condition extends CssNodeCommon {
+    type: 'Condition';
+    kind: string;
+    children: List<CssNode>;
+  }
+
+  export interface ConditionPlain extends CssNodeCommon {
+    type: 'Condition';
+    kind: string;
+    children: CssNodePlain[];
+  }
+
+  export interface Comment extends CssNodeCommon {
+    type: 'Comment';
+    value: string;
+  }
+
+  export interface Declaration extends CssNodeCommon {
+    type: 'Declaration';
+    important: boolean | string;
+    property: string;
+    value: Value | Raw;
+  }
+
+  export interface DeclarationPlain extends CssNodeCommon {
+    type: 'Declaration';
+    important: boolean | string;
+    property: string;
+    value: ValuePlain | Raw;
+  }
+
+  export interface DeclarationList extends CssNodeCommon {
+    type: 'DeclarationList';
+    children: List<CssNode>;
+  }
+
+  export interface DeclarationListPlain extends CssNodeCommon {
+    type: 'DeclarationList';
+    children: CssNodePlain[];
+  }
+
+  export interface Dimension extends CssNodeCommon {
+    type: 'Dimension';
+    value: string;
+    unit: string;
+  }
+
+  export interface FunctionNode extends CssNodeCommon {
+    type: 'Function';
+    name: string;
+    children: List<CssNode>;
+  }
+
+  export interface FunctionNodePlain extends CssNodeCommon {
+    type: 'Function';
+    name: string;
+    children: CssNodePlain[];
+  }
+
+  export interface Hash extends CssNodeCommon {
+    type: 'Hash';
+    value: string;
+  }
+
+  export interface IdSelector extends CssNodeCommon {
+    type: 'IdSelector';
+    name: string;
+  }
+
+  export interface Identifier extends CssNodeCommon {
+    type: 'Identifier';
+    name: string;
+  }
+
+  export interface MediaFeature extends CssNodeCommon {
+    type: 'MediaFeature';
+    name: string;
+    value: Identifier | NumberNode | Dimension | Ratio | null;
+  }
+
+  export interface MediaQuery extends CssNodeCommon {
+    type: 'MediaQuery';
+    children: List<CssNode>;
+  }
+
+  export interface MediaQueryPlain extends CssNodeCommon {
+    type: 'MediaQuery';
+    children: CssNodePlain[];
+  }
+
+  export interface MediaQueryList extends CssNodeCommon {
+    type: 'MediaQueryList';
+    children: List<CssNode>;
+  }
+
+  export interface MediaQueryListPlain extends CssNodeCommon {
+    type: 'MediaQueryList';
+    children: CssNodePlain[];
+  }
+
+  export interface NestingSelector extends CssNodeCommon {
+    type: 'NestingSelector';
+  }
+
+  export interface Nth extends CssNodeCommon {
+    type: 'Nth';
+    nth: AnPlusB | Identifier;
+    selector: SelectorList | null;
+  }
+
+  export interface NthPlain extends CssNodeCommon {
+    type: 'Nth';
+    nth: AnPlusB | Identifier;
+    selector: SelectorListPlain | null;
+  }
+
+  export interface NumberNode extends CssNodeCommon {
+    type: 'Number';
+    value: string;
+  }
+
+  export interface Operator extends CssNodeCommon {
+    type: 'Operator';
+    value: string;
+  }
+
+  export interface Parentheses extends CssNodeCommon {
+    type: 'Parentheses';
+    children: List<CssNode>;
+  }
+
+  export interface ParenthesesPlain extends CssNodeCommon {
+    type: 'Parentheses';
+    children: CssNodePlain[];
+  }
+
+  export interface Percentage extends CssNodeCommon {
+    type: 'Percentage';
+    value: string;
+  }
+
+  export interface PseudoClassSelector extends CssNodeCommon {
+    type: 'PseudoClassSelector';
+    name: string;
+    children: List<CssNode> | null;
+  }
+
+  export interface PseudoClassSelectorPlain extends CssNodeCommon {
+    type: 'PseudoClassSelector';
+    name: string;
+    children: CssNodePlain[] | null;
+  }
+
+  export interface PseudoElementSelector extends CssNodeCommon {
+    type: 'PseudoElementSelector';
+    name: string;
+    children: List<CssNode> | null;
+  }
+
+  export interface PseudoElementSelectorPlain extends CssNodeCommon {
+    type: 'PseudoElementSelector';
+    name: string;
+    children: CssNodePlain[] | null;
+  }
+
+  export interface Ratio extends CssNodeCommon {
+    type: 'Ratio';
+    left: string;
+    right: string;
+  }
+
+  export interface Raw extends CssNodeCommon {
+    type: 'Raw';
+    value: string;
+  }
+
+  export interface Rule extends CssNodeCommon {
+    type: 'Rule';
+    prelude: SelectorList | Raw;
+    block: Block;
+  }
+
+  export interface RulePlain extends CssNodeCommon {
+    type: 'Rule';
+    prelude: SelectorListPlain | Raw;
+    block: BlockPlain;
+  }
+
+  export interface Selector extends CssNodeCommon {
+    type: 'Selector';
+    children: List<CssNode>;
+  }
+
+  export interface SelectorPlain extends CssNodeCommon {
+    type: 'Selector';
+    children: CssNodePlain[];
+  }
+
+  export interface SelectorList extends CssNodeCommon {
+    type: 'SelectorList';
+    children: List<CssNode>;
+  }
+
+  export interface SelectorListPlain extends CssNodeCommon {
+    type: 'SelectorList';
+    children: CssNodePlain[];
+  }
+
+  export interface StringNode extends CssNodeCommon {
+    type: 'String';
+    value: string;
+  }
+
+  export interface StyleSheet extends CssNodeCommon {
+    type: 'StyleSheet';
+    children: List<CssNode>;
+  }
+
+  export interface StyleSheetPlain extends CssNodeCommon {
+    type: 'StyleSheet';
+    children: CssNodePlain[];
+  }
+
+  export interface TypeSelector extends CssNodeCommon {
+    type: 'TypeSelector';
+    name: string;
+  }
+
+  export interface UnicodeRange extends CssNodeCommon {
+    type: 'UnicodeRange';
+    value: string;
+  }
+
+  export interface Url extends CssNodeCommon {
+    type: 'Url';
+    value: string;
+  }
+
+  export interface Value extends CssNodeCommon {
+    type: 'Value';
+    children: List<CssNode>;
+  }
+
+  export interface ValuePlain extends CssNodeCommon {
+    type: 'Value';
+    children: CssNodePlain[];
+  }
+
+  export interface WhiteSpace extends CssNodeCommon {
+    type: 'WhiteSpace';
+    value: string;
+  }
+
+  export type CssNode =
+    | AnPlusB
+    | Atrule
+    | AtrulePrelude
+    | AttributeSelector
+    | Block
+    | Brackets
+    | CDC
+    | CDO
+    | ClassSelector
+    | Combinator
+    | Comment
+    | Condition
+    | Declaration
+    | DeclarationList
+    | Dimension
+    | FunctionNode
+    | Hash
+    | IdSelector
+    | Identifier
+    | MediaFeature
+    | MediaQuery
+    | MediaQueryList
+    | NestingSelector
+    | Nth
+    | NumberNode
+    | Operator
+    | Parentheses
+    | Percentage
+    | PseudoClassSelector
+    | PseudoElementSelector
+    | Ratio
+    | Raw
+    | Rule
+    | Selector
+    | SelectorList
+    | StringNode
+    | StyleSheet
+    | TypeSelector
+    | UnicodeRange
+    | Url
+    | Value
+    | WhiteSpace;
+
+  export type CssNodePlain =
+    | AnPlusB
+    | AtrulePlain
+    | AtrulePreludePlain
+    | AttributeSelector
+    | BlockPlain
+    | BracketsPlain
+    | CDC
+    | CDO
+    | ClassSelector
+    | Combinator
+    | Comment
+    | ConditionPlain
+    | DeclarationPlain
+    | DeclarationListPlain
+    | Dimension
+    | FunctionNodePlain
+    | Hash
+    | IdSelector
+    | Identifier
+    | MediaFeature
+    | MediaQueryPlain
+    | MediaQueryListPlain
+    | NthPlain
+    | NumberNode
+    | Operator
+    | ParenthesesPlain
+    | Percentage
+    | PseudoClassSelectorPlain
+    | PseudoElementSelectorPlain
+    | Ratio
+    | Raw
+    | RulePlain
+    | SelectorPlain
+    | SelectorListPlain
+    | StringNode
+    | StyleSheetPlain
+    | TypeSelector
+    | UnicodeRange
+    | Url
+    | ValuePlain
+    | WhiteSpace;
+
+  export interface SyntaxParseError extends SyntaxError {
+    input: string;
+    offset: number;
+    rawMessage: string;
+    formattedMessage: string;
+  }
+
+  export interface ParseOptions {
+    context?: string | undefined;
+    atrule?: string | undefined;
+    positions?: boolean | undefined;
+    onComment?: (value: string, loc: CssLocation) => void;
+    onParseError?: ((error: SyntaxParseError, fallbackNode: CssNode) => void) | undefined;
+    filename?: string | undefined;
+    offset?: number | undefined;
+    line?: number | undefined;
+    column?: number | undefined;
+    parseAtrulePrelude?: boolean | undefined;
+    parseRulePrelude?: boolean | undefined;
+    parseValue?: boolean | undefined;
+    parseCustomProperty?: boolean | undefined;
+  }
+
+  export function parse(text: string, options?: ParseOptions): CssNode;
+  export function tokenize(source: string, onToken: (type: number, start: number, offset?: number) => void): void;
+
+  export interface GenerateHandlers {
+    children: (node: CssNode, delimiter?: (node: CssNode) => void) => void;
+    node: (node: CssNode) => void;
+    chunk: (chunk: string) => void;
+    result: () => string;
+  }
+
+  export interface GenerateOptions {
+    sourceMap?: boolean | undefined;
+    decorator?: ((handlers: GenerateHandlers) => GenerateHandlers) | undefined;
+    mode?: 'safe' | 'spec' | undefined;
+  }
+
+  export function generate(ast: CssNode, options?: GenerateOptions): string;
+
+  export interface WalkContext {
+    /** Stops traversal. No visitor function will be invoked once this value is returned by a visitor. */
+    break: symbol;
+    /**
+     * Prevent the current node from being iterated. No visitor function will be invoked for its properties or children
+     * nodes; note that this value only has an effect for enter visitor as leave visitor invokes after iterating over
+     * all node's properties and children.
+     */
+    skip: symbol;
+    root: CssNode;
+    stylesheet: StyleSheet | null;
+    atrule: Atrule | null;
+    atrulePrelude: AtrulePrelude | null;
+    rule: Rule | null;
+    selector: SelectorList | null;
+    block: Block | null;
+    declaration: Declaration | null;
+    function: FunctionNode | PseudoClassSelector | PseudoElementSelector | null;
+  }
+
+  export type EnterOrLeaveFn<NodeType = CssNode> = (
+    this: WalkContext,
+    node: NodeType,
+    item: ListItem<CssNode>,
+    list: List<CssNode>,
+  ) => void;
+
+  export interface WalkOptionsNoVisit {
+    enter?: EnterOrLeaveFn | undefined;
+    leave?: EnterOrLeaveFn | undefined;
+    reverse?: boolean | undefined;
+  }
+
+  export interface WalkOptionsVisit<NodeType extends CssNode = CssNode> {
+    visit: NodeType['type'];
+    enter?: EnterOrLeaveFn<NodeType> | undefined;
+    leave?: EnterOrLeaveFn<NodeType> | undefined;
+    reverse?: boolean | undefined;
+  }
+
+  export type WalkOptions =
+    | WalkOptionsVisit<AnPlusB>
+    | WalkOptionsVisit<Atrule>
+    | WalkOptionsVisit<AtrulePrelude>
+    | WalkOptionsVisit<AttributeSelector>
+    | WalkOptionsVisit<Block>
+    | WalkOptionsVisit<Brackets>
+    | WalkOptionsVisit<CDC>
+    | WalkOptionsVisit<CDO>
+    | WalkOptionsVisit<ClassSelector>
+    | WalkOptionsVisit<Combinator>
+    | WalkOptionsVisit<Comment>
+    | WalkOptionsVisit<Declaration>
+    | WalkOptionsVisit<DeclarationList>
+    | WalkOptionsVisit<Dimension>
+    | WalkOptionsVisit<FunctionNode>
+    | WalkOptionsVisit<Hash>
+    | WalkOptionsVisit<IdSelector>
+    | WalkOptionsVisit<Identifier>
+    | WalkOptionsVisit<MediaFeature>
+    | WalkOptionsVisit<MediaQuery>
+    | WalkOptionsVisit<MediaQueryList>
+    | WalkOptionsVisit<Nth>
+    | WalkOptionsVisit<NumberNode>
+    | WalkOptionsVisit<Operator>
+    | WalkOptionsVisit<Parentheses>
+    | WalkOptionsVisit<Percentage>
+    | WalkOptionsVisit<PseudoClassSelector>
+    | WalkOptionsVisit<PseudoElementSelector>
+    | WalkOptionsVisit<Ratio>
+    | WalkOptionsVisit<Raw>
+    | WalkOptionsVisit<Rule>
+    | WalkOptionsVisit<Selector>
+    | WalkOptionsVisit<SelectorList>
+    | WalkOptionsVisit<StringNode>
+    | WalkOptionsVisit<StyleSheet>
+    | WalkOptionsVisit<TypeSelector>
+    | WalkOptionsVisit<UnicodeRange>
+    | WalkOptionsVisit<Url>
+    | WalkOptionsVisit<Value>
+    | WalkOptionsVisit<WhiteSpace>
+    | WalkOptionsNoVisit;
+
+  export const walk: {
+    (ast: CssNode, options: EnterOrLeaveFn | WalkOptions): void;
+    /** Stops traversal. No visitor function will be invoked once this value is returned by a visitor. */
+    readonly break: symbol;
+    /**
+     * Prevent the current node from being iterated. No visitor function will be invoked for its properties or children
+     * nodes; note that this value only has an effect for enter visitor as leave visitor invokes after iterating over
+     * all node's properties and children.
+     */
+    readonly skip: symbol;
+  };
+
+  export type FindFn = (this: WalkContext, node: CssNode, item: ListItem<CssNode>, list: List<CssNode>) => boolean;
+
+  export function find(ast: CssNode, fn: FindFn): CssNode | null;
+  export function findLast(ast: CssNode, fn: FindFn): CssNode | null;
+  export function findAll(ast: CssNode, fn: FindFn): CssNode[];
+
+  export interface Property {
+    readonly basename: string;
+    readonly name: string;
+    readonly hack: string;
+    readonly vendor: string;
+    readonly prefix: string;
+    readonly custom: boolean;
+  }
+
+  export function property(value: string): Property;
+
+  export interface Keyword {
+    readonly basename: string;
+    readonly name: string;
+    readonly vendor: string;
+    readonly prefix: string;
+    readonly custom: boolean;
+  }
+
+  export function keyword(value: string): Keyword;
+
+  export function clone(node: CssNode): CssNode;
+
+  export function fromPlainObject(node: CssNodePlain): CssNode;
+  export function toPlainObject(node: CssNode): CssNodePlain;
+
+  /** Definition syntax AtWord node */
+  export interface DSNodeAtWord {
+    type: 'AtKeyword';
+    name: string;
+  }
+
+  /** Definition syntax Comma node */
+  export interface DSNodeComma {
+    type: 'Comma';
+  }
+
+  /** Definition syntax Function node */
+  export interface DSNodeFunction {
+    type: 'Function';
+    name: string;
+  }
+
+  export type DSNodeCombinator = '|' | '||' | '&&' | ' ';
+
+  /** Definition syntax Group node */
+  export interface DSNodeGroup {
+    type: 'Group';
+    terms: DSNode[];
+    combinator: DSNodeCombinator;
+    disallowEmpty: boolean;
+    explicit: boolean;
+  }
+
+  /** Definition syntax Keyword node */
+  export interface DSNodeKeyword {
+    type: 'Keyword';
+    name: string;
+  }
+
+  /** Definition syntax Multiplier node */
+  export interface DSNodeMultiplier {
+    type: 'Multiplier';
+    comma: boolean;
+    min: number;
+    max: number;
+    term: DSNodeMultiplied;
+  }
+
+  /** Definition syntax Property node */
+  export interface DSNodeProperty {
+    type: 'Property';
+    name: string;
+  }
+
+  /** Definition syntax String node */
+  export interface DSNodeString {
+    type: 'String';
+    value: string;
+  }
+
+  /** Definition syntax Token node */
+  export interface DSNodeToken {
+    type: 'Token';
+    value: string;
+  }
+
+  /** Definition syntax Type node options */
+  export interface DSNodeTypeOpts {
+    type: 'Range';
+    min: number | null;
+    max: number | null;
+  }
+
+  /** Definition syntax Type node */
+  export interface DSNodeType {
+    type: 'Type';
+    name: string;
+    opts: DSNodeTypeOpts | null;
+  }
+
+  /** Definition syntax node */
+  export type DSNode =
+    | DSNodeAtWord
+    | DSNodeComma
+    | DSNodeFunction
+    | DSNodeGroup
+    | DSNodeKeyword
+    | DSNodeMultiplier
+    | DSNodeProperty
+    | DSNodeString
+    | DSNodeToken
+    | DSNodeType;
+
+  /** Definition syntax node compatible with a multiplier */
+  export type DSNodeMultiplied =
+    | DSNodeFunction
+    | DSNodeGroup
+    | DSNodeKeyword
+    | DSNodeProperty
+    | DSNodeString
+    | DSNodeType;
+
+  /** Definition syntax generate options */
+  export interface DSGenerateOptions {
+    forceBraces?: boolean | undefined;
+    compact?: boolean | undefined;
+    decorate?: ((result: string, node: DSNode) => void) | undefined;
+  }
+
+  /** Definition syntax walk options */
+  export interface DSWalkOptions {
+    enter?: DSWalkEnterOrLeaveFn | undefined;
+    leave?: DSWalkEnterOrLeaveFn | undefined;
+  }
+
+  /** Definition syntax walk callback */
+  export type DSWalkEnterOrLeaveFn = (node: DSNode) => void;
+
+  /** DefinitionSyntax */
+  export interface DefinitionSyntax {
+    /**
+     * Generates CSS value definition syntax from an AST
+     *
+     * @example
+     *   generate({type: 'Keyword', name: 'foo'}) => 'foo'
+     *
+     * @param node - The AST
+     * @param options - Options that affect generation
+     */
+    generate(node: DSNode, options?: DSGenerateOptions): string;
+
+    /**
+     * Generates an AST from a CSS value syntax
+     *
+     * @example
+     *   parse('foo | bar') =>
+     *   {
+     *   type: 'Group',
+     *   terms: [
+     *   { type: 'Keyword', name: 'foo' },
+     *   { type: 'Keyword', name: 'bar' }
+     *   ],
+     *   combinator: '|',
+     *   disallowEmpty: false,
+     *   explicit: false
+     *   }
+     *
+     * @param source - The CSS value syntax to parse
+     */
+    parse(source: string): DSNodeGroup;
+
+    /** Walks definition syntax AST */
+    walk(node: DSNode, options: DSWalkEnterOrLeaveFn | DSWalkOptions, context?: any): void;
+
+    /** Wrapper for syntax errors */
+    syntaxError: SyntaxError;
+  }
+
+  export const definitionSyntax: DefinitionSyntax;
+
+  export const ident: {
+    decode(input: string): string;
+    encode(input: string): string;
+  };
+
+  export const string: {
+    encode(input: string, apostrophe?: boolean): string;
+    decode(input: string): string;
+  };
+
+  export const url: {
+    decode(input: string): string;
+    encode(input: string): string;
+  };
+
+  export class SyntaxMatchError extends SyntaxError {
+    rawMessage: string;
+    syntax: string;
+    css: string;
+    mismatchOffset: number;
+    mismatchLength: number;
+    offset: number;
+    line: number;
+    column: number;
+    loc: {
+      source: string;
+      start: { offset: number; line: number; column: number };
+      end: { offset: number; line: number; column: number };
+    };
+  }
+
+  export class SyntaxReferenceError extends SyntaxError {
+    reference: string;
+  }
+
+  export interface LexerMatchResult {
+    error: Error | SyntaxMatchError | SyntaxReferenceError | null;
+  }
+
+  export class Lexer {
+    matchAtruleDescriptor(atruleName: string, descriptorName: string, value: CssNode | string): LexerMatchResult;
+    matchAtrulePrelude(atruleName: string, prelude: CssNode | string): LexerMatchResult;
+    matchDeclaration(node: CssNode): LexerMatchResult;
+    matchProperty(propertyName: string, value: CssNode | string): LexerMatchResult;
+    matchType(typeName: string, value: CssNode | string): LexerMatchResult;
+    match(syntax: DSNode | string, value: CssNode | string): LexerMatchResult;
+  }
+
+  export const lexer: Lexer;
+
+  export function fork(extension: Partial<SyntaxConfig>): CSSTreeSyntax;
+
+  export interface ParseContext {
+    default: string;
+    stylesheet: string;
+    atrule: string;
+    atrulePrelude: (options: { atrule?: string }) => AtrulePrelude;
+    mediaQueryList: string;
+    mediaQuery: string;
+    condition: (options: { kind: string }) => Condition;
+    rule: string;
+    selectorList: string;
+    selector: string;
+    block: () => Block;
+    declarationList: string;
+    declaration: string;
+    value: string;
+  }
+
+  export interface NodeDefinition {
+    name: string;
+    walkContext?: string;
+    structure: Record<string, unknown>;
+    parse(...args: unknown[]): CssNode;
+    generate(node: CssNode): void;
+  }
+
+  export interface ScopeDefinition {
+    getNode(context: unknown): CssNode;
+    onWhitespace?(next: CssNode, children: NodeList): void;
+  }
+
+  export interface MDNSyntaxDefinition {
+    comment?: string;
+    references?: string[];
+    syntax: string;
+  }
+
+  export interface MDNAtruleDefinition {
+    prelude?: string;
+    descriptors?: Record<string, string | MDNSyntaxDefinition>;
+    comment?: string;
+  }
+
+  export interface SyntaxConfig {
+    atrules: Record<string, MDNAtruleDefinition>;
+    cssWideKeywords: string[];
+    features: Record<
+      string,
+      {
+        selector?(): Selector;
+        style?(): Declaration;
+      }
+    >;
+    generic: boolean;
+    node: Record<string, NodeDefinition>;
+    parseContext: ParseContext;
+    properties: Record<string, string>;
+    scope: Record<string, ScopeDefinition>;
+    types: Record<string, string>;
+    units: Record<string, string[]>;
+  }
+
+  export interface CSSTreeSyntax {
+    lexer: Lexer | null;
+    createLexer(config: SyntaxConfig): Lexer;
+
+    tokenize: typeof tokenize;
+    parse: typeof parse;
+    generate: typeof generate;
+
+    walk: typeof walk;
+    find: typeof find;
+    findLast: typeof findLast;
+    findAll: typeof findAll;
+
+    fromPlainObject: typeof fromPlainObject;
+    toPlainObject: typeof toPlainObject;
+    fork: typeof fork;
+  }
+
+  export function createSyntax(config: SyntaxConfig): CSSTreeSyntax;
+}

--- a/packages/eslint-config/typings/css-tree/package.json
+++ b/packages/eslint-config/typings/css-tree/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@types/css-tree",
+  "private": true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@eslint/compat':
         specifier: 1.2.6
         version: 1.2.6(eslint@9.20.1(jiti@2.4.0))
+      '@eslint/css':
+        specifier: 0.4.0
+        version: 0.4.0
       '@eslint/js':
         specifier: 9.20.0
         version: 9.20.0
@@ -1088,6 +1091,10 @@ packages:
     resolution: {integrity: sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/css@0.4.0':
+    resolution: {integrity: sha512-aEvoIhIxa6nHvqTQxg56YgV8/9FO78ka1XnqkVnM07ZqJgeeILCNOHzwPs1z0N1vlj0Um2s4yMG8Ilau+D05Hg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@3.2.0':
     resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2056,6 +2063,9 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/css-tree@file:packages/eslint-config/typings/css-tree':
+    resolution: {directory: packages/eslint-config/typings/css-tree, type: directory}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -2781,6 +2791,10 @@ packages:
 
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
@@ -4360,6 +4374,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -7763,6 +7780,13 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/css@0.4.0':
+    dependencies:
+      '@eslint/core': 0.10.0
+      '@eslint/plugin-kit': 0.2.5
+      '@types/css-tree': file:packages/eslint-config/typings/css-tree
+      css-tree: 3.1.0
+
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
@@ -8992,6 +9016,8 @@ snapshots:
       '@types/node': 22.13.4
       '@types/responselike': 1.0.3
 
+  '@types/css-tree@file:packages/eslint-config/typings/css-tree': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
@@ -9821,6 +9847,11 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.1.0
       nth-check: 2.1.1
+
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.0
 
   css-what@6.1.0: {}
 
@@ -11709,6 +11740,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.3
+
+  mdn-data@2.12.2: {}
 
   mdurl@2.0.0: {}
 


### PR DESCRIPTION
Added CSS linting support by integrating @eslint/css and its type definitions. This enables static analysis and validation of CSS code within the project.

The changes include:
- Added @eslint/css dependency
- Created type definitions for css-tree
- Updated ESLint config to disable specific rules for CSS type files

<!-- greptile_comment -->

## Greptile Summary

Added CSS linting support by integrating @eslint/css and providing comprehensive type definitions for css-tree, enabling static analysis and validation of CSS code within the project.

- Added `@eslint/css` v0.4.0 dependency in `packages/eslint-config/package.json`
- Created extensive type definitions in `packages/eslint-config/typings/css-tree/index.d.ts` for css-tree AST nodes and utilities
- Modified `eslint.config.ts` to disable TypeScript rules `@2digits/type-param-names` and `ts/no-explicit-any` for css-tree type definitions
- Added private package configuration in `packages/eslint-config/typings/css-tree/package.json` for internal type definitions



<!-- /greptile_comment -->