### PR TITLE
Added @eslint/css linting support

### DIFF
--- a/.changeset/shaggy-corners-read.md
+++ b/.changeset/shaggy-corners-read.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': major
+---
+
+Added @eslint/css for css linting

--- a/packages/eslint-config/src/configs/css.ts
+++ b/packages/eslint-config/src/configs/css.ts
@@ -1,0 +1,25 @@
+import plugin from '@eslint/css';
+import { tailwindSyntax } from '@eslint/css/syntax';
+
+import { GLOB_CSS } from '../globs';
+import type { TypedFlatConfigItem } from '../types';
+
+export function css(): TypedFlatConfigItem[] {
+  return [
+    {
+      name: '2digits:css',
+      files: [GLOB_CSS],
+      language: 'css/css',
+      plugins: {
+        css: plugin,
+      },
+      languageOptions: {
+        tolerant: true,
+        customSyntax: tailwindSyntax,
+      },
+      rules: {
+        ...plugin.configs.recommended.rules,
+      },
+    },
+  ];
+}

--- a/packages/eslint-config/src/configs/index.ts
+++ b/packages/eslint-config/src/configs/index.ts
@@ -1,6 +1,7 @@
 export * from './antfu';
 export * from './boolean';
 export * from './comments';
+export * from './css';
 export * from './drizzle';
 export * from './graphql';
 export * from './ignores';

--- a/packages/eslint-config/src/factory.ts
+++ b/packages/eslint-config/src/factory.ts
@@ -5,6 +5,8 @@ import {
   antfu,
   boolean,
   comments,
+  css,
+  drizzle,
   graphql,
   ignores,
   javascript,
@@ -23,7 +25,6 @@ import {
   typescript,
   unicorn,
 } from './configs';
-import { drizzle } from './configs/drizzle';
 import { PluginNameMap } from './constants';
 import type {
   ConfigNames,
@@ -88,6 +89,7 @@ export function twoDigits(
     regexp(),
     antfu(),
     jsonc(),
+    css(),
   );
 
   if (enabled(options.turbo, isPackageExists('turbo'))) {

--- a/packages/eslint-config/src/globs.ts
+++ b/packages/eslint-config/src/globs.ts
@@ -9,6 +9,8 @@ export const GLOB_JSON = '**/*.json';
 export const GLOB_JSON5 = '**/*.json5';
 export const GLOB_JSONC = '**/*.jsonc';
 
+export const GLOB_CSS = '**/*.css';
+
 export const GLOB_EXCLUDE = [
   '**/node_modules',
   '**/dist',

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -246,6 +246,35 @@ export interface RuleOptions {
    */
   'constructor-super'?: Linter.RuleEntry<[]>
   /**
+   * Disallow duplicate @import rules
+   * @see https://github.com/eslint/css/blob/main/docs/rules/no-duplicate-imports.md
+   */
+  'css/no-duplicate-imports'?: Linter.RuleEntry<[]>
+  /**
+   * Disallow empty blocks
+   * @see https://github.com/eslint/css/blob/main/docs/rules/no-empty-blocks.md
+   */
+  'css/no-empty-blocks'?: Linter.RuleEntry<[]>
+  /**
+   * Disallow invalid at-rules
+   * @see https://github.com/eslint/css/blob/main/docs/rules/no-invalid-at-rules.md
+   */
+  'css/no-invalid-at-rules'?: Linter.RuleEntry<[]>
+  /**
+   * Disallow invalid properties
+   * @see https://github.com/eslint/css/blob/main/docs/rules/no-invalid-properties.md
+   */
+  'css/no-invalid-properties'?: Linter.RuleEntry<[]>
+  /**
+   * Enforce the use of baseline features
+   */
+  'css/require-baseline'?: Linter.RuleEntry<CssRequireBaseline>
+  /**
+   * Require use of layers
+   * @see https://github.com/eslint/css/blob/main/docs/rules/use-layers.md
+   */
+  'css/use-layers'?: Linter.RuleEntry<CssUseLayers>
+  /**
    * Enforce consistent brace style for all control statements
    * @see https://eslint.org/docs/latest/rules/curly
    */
@@ -7195,6 +7224,16 @@ type ConsistentReturn = []|[{
 }]
 // ----- consistent-this -----
 type ConsistentThis = string[]
+// ----- css/require-baseline -----
+type CssRequireBaseline = []|[{
+  available?: ("widely" | "newly")
+}]
+// ----- css/use-layers -----
+type CssUseLayers = []|[{
+  allowUnnamedLayers?: boolean
+  requireImportLayers?: boolean
+  layerNamePattern?: string
+}]
 // ----- curly -----
 type Curly = ([]|["all"] | []|[("multi" | "multi-line" | "multi-or-nest")]|[("multi" | "multi-line" | "multi-or-nest"), "consistent"])
 // ----- default-case -----
@@ -12089,4 +12128,4 @@ type Yoda = []|[("always" | "never")]|[("always" | "never"), {
   onlyEquality?: boolean
 }]
 // Names of all the configs
-export type ConfigNames = '2digits:antfu' | '2digits:boolean' | '2digits:comments' | '2digits:drizzle' | '2digits:graphql' | '2digits:ignores' | '2digits:gitignore' | '2digits:javascript' | '2digits:jsdoc' | '2digits:jsonc/base' | '2digits:jsonc/base' | '2digits:jsonc/json' | '2digits:jsonc/jsonc' | '2digits:jsonc/json5' | '2digits:jsonc/package.json' | '2digits:jsonc/tsconfig.json' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:next/setup' | '2digits:next/rules' | '2digits:node' | '2digits:prettier' | '2digits:react/setup' | '2digits:react/rules' | '2digits:regexp' | '2digits:sonar' | '2digits:storybook/setup' | '2digits:storybook/rules' | '2digits:storybook/disables' | '2digits:storybook/config' | '2digits:tailwind' | '2digits:tanstack' | '2digits:turbo' | '2digits:typescript/setup' | '2digits:typescript/rules' | '2digits:typescript/disables/dts' | '2digits:typescript/disables/test' | '2digits:typescript/disables/cjs' | '2digits:unicorn'
+export type ConfigNames = '2digits:antfu' | '2digits:boolean' | '2digits:comments' | '2digits:css/recommended' | '2digits:drizzle' | '2digits:graphql' | '2digits:ignores' | '2digits:gitignore' | '2digits:javascript' | '2digits:jsdoc' | '2digits:jsonc/base' | '2digits:jsonc/base' | '2digits:jsonc/json' | '2digits:jsonc/jsonc' | '2digits:jsonc/json5' | '2digits:jsonc/package.json' | '2digits:jsonc/tsconfig.json' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:next/setup' | '2digits:next/rules' | '2digits:node' | '2digits:prettier' | '2digits:react/setup' | '2digits:react/rules' | '2digits:regexp' | '2digits:sonar' | '2digits:storybook/setup' | '2digits:storybook/rules' | '2digits:storybook/disables' | '2digits:storybook/config' | '2digits:tailwind' | '2digits:tanstack' | '2digits:turbo' | '2digits:typescript/setup' | '2digits:typescript/rules' | '2digits:typescript/disables/dts' | '2digits:typescript/disables/test' | '2digits:typescript/disables/cjs' | '2digits:unicorn'

--- a/packages/eslint-config/src/types.ts
+++ b/packages/eslint-config/src/types.ts
@@ -21,7 +21,7 @@ export interface TypedFlatConfigItem
   // eslint-disable-next-line ts/no-explicit-any
   plugins?: Record<string, any>;
 
-  languageOptions?: FlatConfig.LanguageOptions;
+  languageOptions?: FlatConfig.LanguageOptions & Record<string, unknown>;
 }
 
 export interface OptionsOverrides {


### PR DESCRIPTION
Added CSS linting support using @eslint/css plugin with Tailwind syntax integration. This enables CSS validation with recommended rules and includes support for:

- Duplicate @import detection
- Empty block validation
- At-rule validation
- Property validation
- CSS layer usage
- Baseline feature enforcement

The configuration is automatically applied to all .css files in the project.

<!-- greptile_comment -->

## Greptile Summary

Added CSS linting support using @eslint/css plugin with Tailwind syntax integration, enabling comprehensive CSS validation with recommended rules and Tailwind-specific syntax checking.

- Added new `packages/eslint-config/src/configs/css.ts` implementing CSS linting with Tailwind syntax support
- Added `GLOB_CSS` pattern in `packages/eslint-config/src/globs.ts` for matching CSS files
- Modified `packages/eslint-config/src/factory.ts` to include CSS linting in base configuration without opt-out option
- Extended `TypedFlatConfigItem` interface in `packages/eslint-config/src/types.ts` to support CSS plugin's language options



<!-- /greptile_comment -->