### PR TITLE
✨ Added shell formatting

### DIFF
--- a/.changeset/lucky-donkeys-fail.md
+++ b/.changeset/lucky-donkeys-fail.md
@@ -1,0 +1,5 @@
+---
+'@2digits/prettier-config': major
+---
+
+Added prettier-plugin-sh for shell formatting

--- a/.gitignore
+++ b/.gitignore
@@ -141,9 +141,6 @@ dist
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
-Icon
-
 # Thumbnails
 ._*
 

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -44,6 +44,7 @@
     "local-pkg": "1.0.0",
     "prettier-plugin-embed": "0.4.15",
     "prettier-plugin-jsdoc": "1.3.2",
+    "prettier-plugin-sh": "0.15.0",
     "prettier-plugin-sql": "0.18.1",
     "prettier-plugin-tailwindcss": "0.6.11",
     "prettier-plugin-toml": "2.0.2"

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -38,12 +38,16 @@ export default defineConfig({
   language: 'sqlite',
   keywordCase: 'upper',
 
+  experimentalWasm: true,
+  indent: 2,
+
   plugins: [
     require.resolve('prettier-plugin-toml'),
     require.resolve('@prettier/plugin-xml'),
     require.resolve('@ianvs/prettier-plugin-sort-imports'),
     require.resolve('prettier-plugin-jsdoc'),
     require.resolve('prettier-plugin-sql'),
+    require.resolve('prettier-plugin-sh'),
     require.resolve('prettier-plugin-embed'),
     require.resolve('prettier-plugin-tailwindcss'),
   ],

--- a/packages/prettier-config/src/utils.ts
+++ b/packages/prettier-config/src/utils.ts
@@ -2,6 +2,7 @@ import type { PrettierConfig as ImportOrderConfig } from '@ianvs/prettier-plugin
 import { getPackageInfoSync } from 'local-pkg';
 import type { Options } from 'prettier';
 import type { PluginEmbedOptions } from 'prettier-plugin-embed';
+import type { ShParserOptions } from 'prettier-plugin-sh';
 import type { SqlFormatOptions } from 'prettier-plugin-sql';
 import type { PluginOptions } from 'prettier-plugin-tailwindcss';
 import type { PrettierTaploOptions } from 'prettier-plugin-toml';
@@ -16,7 +17,8 @@ type PrettierConfigWithPlugins = Options
   & PluginOptions
   & SqlFormatOptions
   & PrettierTaploOptions
-  & PluginEmbedOptions;
+  & PluginEmbedOptions
+  & Partial<ShParserOptions>;
 
 /**
  * Define a Prettier configuration with plugins.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       prettier-plugin-jsdoc:
         specifier: 1.3.2
         version: 1.3.2(prettier@3.5.1)
+      prettier-plugin-sh:
+        specifier: 0.15.0
+        version: 0.15.0(prettier@3.5.1)
       prettier-plugin-sql:
         specifier: 0.18.1
         version: 0.18.1(prettier@3.5.1)
@@ -4626,6 +4629,9 @@ packages:
     resolution: {integrity: sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==}
     engines: {node: '>=0.8.0'}
 
+  mvdan-sh@0.10.1:
+    resolution: {integrity: sha512-kMbrH0EObaKmK3nVRKUIIya1dpASHIEusM13S4V1ViHFuxuNxCo+arxoa6j/dbV22YBGjl7UKJm9QQKJ2Crzhg==}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -5074,6 +5080,12 @@ packages:
     peerDependencies:
       prettier: ^3.0.0
 
+  prettier-plugin-sh@0.15.0:
+    resolution: {integrity: sha512-U0PikJr/yr2bzzARl43qI0mApBj0C1xdAfA04AZa6LnvIKawXHhuy2fFo6LNA7weRzGlAiNbaEFfKMFo0nZr/A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      prettier: ^3.0.3
+
   prettier-plugin-sql@0.18.1:
     resolution: {integrity: sha512-2+Nob2sg7hzLAKJoE6sfgtkhBZCqOzrWHZPvE4Kee/e80oOyI4qwy9vypeltqNBJwTtq3uiKPrCxlT03bBpOaw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -5491,6 +5503,10 @@ packages:
   set-function-name@2.0.2:
     resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
     engines: {node: '>= 0.4'}
+
+  sh-syntax@0.4.2:
+    resolution: {integrity: sha512-/l2UZ5fhGZLVZa16XQM9/Vq/hezGGbdHeVEA01uWjOL1+7Ek/gt6FquW0iKKws4a9AYPYvlz6RyVvjh3JxOteg==}
+    engines: {node: '>=16.0.0'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -12099,6 +12115,8 @@ snapshots:
       rimraf: 2.4.5
     optional: true
 
+  mvdan-sh@0.10.1: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -12561,6 +12579,12 @@ snapshots:
       prettier: 3.5.1
     transitivePeerDependencies:
       - supports-color
+
+  prettier-plugin-sh@0.15.0(prettier@3.5.1):
+    dependencies:
+      mvdan-sh: 0.10.1
+      prettier: 3.5.1
+      sh-syntax: 0.4.2
 
   prettier-plugin-sql@0.18.1(prettier@3.5.1):
     dependencies:
@@ -13122,6 +13146,10 @@ snapshots:
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
+
+  sh-syntax@0.4.2:
+    dependencies:
+      tslib: 2.8.1
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added shell script formatting support to the Prettier configuration, including necessary plugin integration and configuration options, while also modifying .gitignore file handling for macOS icon files.

- Added `prettier-plugin-sh` v0.15.0 in `packages/prettier-config/package.json` for shell script formatting
- Added `ShParserOptions` type integration in `packages/prettier-config/src/utils.ts` for type safety
- Added `experimentalWasm: true` and `indent: 2` configurations in `packages/prettier-config/src/index.ts`
- Removed Icon-related entries from `.gitignore`, potentially affecting macOS icon file tracking



<!-- /greptile_comment -->