### PR TITLE
🔧 Updated TOML formatting

### DIFF
--- a/.changeset/swift-impalas-attend.md
+++ b/.changeset/swift-impalas-attend.md
@@ -1,0 +1,5 @@
+---
+'@2digits/prettier-config': minor
+---
+
+Updated TOML formatting rules

--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,10 @@
 [tools]
-node = "22.14.0"
-pnpm = "10.4.1"
+  node = "22.14.0"
+  pnpm = "10.4.1"
 
 [env]
-FORCE_COLOR = "1"
-NODE_OPTIONS = "--no-deprecation"
+  FORCE_COLOR = "1"
+  NODE_OPTIONS = "--no-deprecation"
 
 [settings]
-pin = true
+  pin = true

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -41,10 +41,13 @@ export default defineConfig({
   experimentalWasm: true,
   indent: 2,
 
+  allowedBlankLines: 1,
+  indentEntries: true,
+
   plugins: [
-    require.resolve('prettier-plugin-toml'),
     require.resolve('@prettier/plugin-xml'),
     require.resolve('@ianvs/prettier-plugin-sort-imports'),
+    require.resolve('prettier-plugin-toml'),
     require.resolve('prettier-plugin-jsdoc'),
     require.resolve('prettier-plugin-sql'),
     require.resolve('prettier-plugin-sh'),


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated TOML formatting configuration in Prettier, introducing specific indentation rules and reordering plugins for better formatting consistency.

- Added TOML-specific formatting options `allowedBlankLines: 1` and `indentEntries: true` in `/packages/prettier-config/src/index.ts`
- Reordered Prettier plugins to place TOML plugin after XML and sort-imports for optimized formatting priority
- Applied consistent indentation in `/mise.toml` while preserving configuration values
- Moved TOML formatting options to global config which may affect other file types



<!-- /greptile_comment -->