### PR TITLE
🔧 Update renovate config paths

### DIFF
--- a/packages/renovate/default.json
+++ b/packages/renovate/default.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./node_modules/renovate/renovate-schema.json",
-  "extends": ["local>./src/default.json"]
+  "extends": ["local>2digits-agency/configs//packages/renovate/src/default.json"]
 }

--- a/packages/renovate/src/default.json
+++ b/packages/renovate/src/default.json
@@ -1,6 +1,10 @@
 {
   "$schema": "../node_modules/renovate/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests", "local>./nolyfill.json"],
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "local>2digits-agency/configs//packages/renovate/src/nolyfill.json"
+  ],
   "automergeType": "pr",
   "platformAutomerge": true,
   "automerge": true,


### PR DESCRIPTION
Updates Renovate configuration to use absolute paths for local extends

The PR modifies the Renovate configuration to use absolute repository paths instead of relative paths when extending local configurations. This ensures proper resolution of local extends when the config is used across different projects.