### PR TITLE
⬆️ Update renovate to 39.192.0

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>./packages/renovate/default.json"]
+  "extends": ["local>2digits-agency/configs//packages/renovate/default"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ catalogs:
       specifier: 2.0.2
       version: 2.0.2
     renovate:
-      specifier: 39.191.4
-      version: 39.191.4
+      specifier: 39.192.0
+      version: 39.192.0
     ts-pattern:
       specifier: 5.6.2
       version: 5.6.2
@@ -510,7 +510,7 @@ importers:
         version: 1.0.44
       renovate:
         specifier: 'catalog:'
-        version: 39.191.4(encoding@0.1.13)(typanion@3.14.0)
+        version: 39.192.0(encoding@0.1.13)(typanion@3.14.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -5088,11 +5088,6 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.5.2:
-    resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
@@ -5285,8 +5280,8 @@ packages:
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
 
-  renovate@39.191.4:
-    resolution: {integrity: sha512-AXfqmSUcvP+PJXXxIyX4DAzBEmrLU0w4iu2kz9Cs0jMKms0g9i5SAxu4QtPXP8fgx+ez/kCBGtnGgIZJ+tMHng==}
+  renovate@39.192.0:
+    resolution: {integrity: sha512-pqfl9TtsNGSU5bbDmaJM8ikFoO4B9Iq9a+uJJtXbyUgqIg5G6NsegiwGABkxKRv5HhpIlx0eBl+/hQkWPUMXvg==}
     engines: {node: ^20.15.1 || ^22.11.0, pnpm: ^10.0.0}
     hasBin: true
 
@@ -11940,8 +11935,6 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.5.2: {}
-
   prettier@3.5.3: {}
 
   proc-log@4.2.0:
@@ -12181,7 +12174,7 @@ snapshots:
 
   remove-trailing-separator@1.1.0: {}
 
-  renovate@39.191.4(encoding@0.1.13)(typanion@3.14.0):
+  renovate@39.192.0(encoding@0.1.13)(typanion@3.14.0):
     dependencies:
       '@aws-sdk/client-codecommit': 3.738.0
       '@aws-sdk/client-ec2': 3.738.0
@@ -12270,7 +12263,7 @@ snapshots:
       p-queue: 6.6.2
       p-throttle: 4.1.1
       parse-link-header: 2.0.0
-      prettier: 3.5.2
+      prettier: 3.5.3
       protobufjs: 7.4.0
       punycode: 2.3.1
       redis: 4.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,7 +58,7 @@ catalog:
   prettier-plugin-sql: 0.18.1
   prettier-plugin-tailwindcss: 0.6.11
   prettier-plugin-toml: 2.0.2
-  renovate: 39.191.4
+  renovate: 39.192.0
   ts-pattern: 5.6.2
   tsup: 8.4.0
   turbo: 2.4.4


### PR DESCRIPTION
Updates Renovate configuration and dependencies

- Points Renovate config to use shared configuration from 2digits-agency/configs
- Updates Renovate from v39.191.4 to v39.192.0
- Updates Prettier dependency used by Renovate to v3.5.3