### PR TITLE
🔧 Update renovate paths from local to github

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>2digits-agency/configs//packages/renovate/default"]
+  "extends": ["github>2digits-agency/configs//packages/renovate/default.json"]
 }

--- a/packages/renovate/default.json
+++ b/packages/renovate/default.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./node_modules/renovate/renovate-schema.json",
-  "extends": ["local>2digits-agency/configs//packages/renovate/src/default.json"]
+  "extends": ["github>2digits-agency/configs//packages/renovate/src/default.json"]
 }

--- a/packages/renovate/src/default.json
+++ b/packages/renovate/src/default.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests",
-    "local>2digits-agency/configs//packages/renovate/src/nolyfill.json"
+    "github>2digits-agency/configs//packages/renovate/src/nolyfill.json"
   ],
   "automergeType": "pr",
   "platformAutomerge": true,


### PR DESCRIPTION
Updates Renovate configuration to use GitHub-hosted config files

Changes all local config file references to use the GitHub-hosted versions, ensuring configs are properly resolved when used across repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration settings to use centralized, GitHub-hosted references instead of local configuration sources. These changes streamline configuration management and ensure that settings are maintained consistently across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->