### PR TITLE
🔧 Add stylistic padding line rules

### DIFF
--- a/.changeset/eleven-wasps-draw.md
+++ b/.changeset/eleven-wasps-draw.md
@@ -1,0 +1,6 @@
+---
+'@2digits/eslint-config': minor
+'@2digits/eslint-plugin': patch
+---
+
+Added `stylistic/padding-line-between-statements` rules

--- a/packages/eslint-config/src/configs/graphql.ts
+++ b/packages/eslint-config/src/configs/graphql.ts
@@ -22,6 +22,7 @@ export async function graphql(options: OptionsWithFiles = {}): Promise<TypedFlat
   } else {
     for (const rule of Object.keys(flatRecommended) as Array<keyof typeof rules>) {
       const ruleName = rule.replace('@graphql-eslint/', '') as keyof typeof gql.rules;
+
       if (
         ruleName in gql.rules
         && (gql.rules[ruleName].meta.docs?.requiresSchema || gql.rules[ruleName].meta.docs?.requiresSiblings)

--- a/packages/eslint-config/src/configs/javascript.ts
+++ b/packages/eslint-config/src/configs/javascript.ts
@@ -1,4 +1,5 @@
 import eslint from '@eslint/js';
+import stylistic from '@stylistic/eslint-plugin';
 import globals from 'globals';
 
 import { GLOB_SRC } from '../globs';
@@ -11,6 +12,9 @@ export function javascript(options: OptionsOverrides = {}): TypedFlatConfigItem[
     {
       files: [GLOB_SRC],
       name: '2digits:javascript',
+      plugins: {
+        stylistic,
+      },
       languageOptions: {
         ecmaVersion: 2022,
         globals: {
@@ -205,6 +209,17 @@ export function javascript(options: OptionsOverrides = {}): TypedFlatConfigItem[
         'valid-typeof': ['error', { requireStringLiterals: true }],
         'vars-on-top': 'error',
         yoda: ['error', 'never'],
+
+        'stylistic/padding-line-between-statements': [
+          'error',
+          { blankLine: 'always', prev: ['const', 'let'], next: '*' },
+          {
+            blankLine: 'any',
+            prev: ['const', 'let'],
+            next: ['const', 'let'],
+          },
+          { blankLine: 'always', prev: '*', next: 'return' },
+        ],
 
         ...overrides,
       },

--- a/packages/eslint-config/src/configs/react.ts
+++ b/packages/eslint-config/src/configs/react.ts
@@ -1,3 +1,4 @@
+import stylistic from '@stylistic/eslint-plugin';
 import { renamePluginsInRules } from 'eslint-flat-config-utils';
 
 import { PluginNameMap } from '../constants';
@@ -10,10 +11,9 @@ export async function react(
 ): Promise<TypedFlatConfigItem[]> {
   const { files = [GLOB_TS, GLOB_TSX], overrides = {}, parserOptions, tsconfigRootDir, reactCompiler = true } = options;
 
-  const [pluginReact, pluginReactHooks, stylistic, parser, pluginReactCompiler] = await Promise.all([
+  const [pluginReact, pluginReactHooks, parser, pluginReactCompiler] = await Promise.all([
     interopDefault(import('@eslint-react/eslint-plugin')),
     interopDefault(import('eslint-plugin-react-hooks')),
-    interopDefault(import('@stylistic/eslint-plugin')),
     interopDefault(import('@typescript-eslint/parser')),
     reactCompiler ? interopDefault(import('eslint-plugin-react-compiler')) : undefined,
   ]);

--- a/packages/eslint-config/src/factory.ts
+++ b/packages/eslint-config/src/factory.ts
@@ -70,6 +70,7 @@ function config<T>(options: SharedOptions<T> | undefined | boolean): T {
   }
 
   const { enable, ...rest } = options;
+
   return rest as T;
 }
 

--- a/packages/eslint-plugin/src/utils/index.ts
+++ b/packages/eslint-plugin/src/utils/index.ts
@@ -51,6 +51,7 @@ function createRule<TOptions extends readonly Record<string, unknown>[], TMessag
           ...options,
         };
       }) as unknown as TOptions;
+
       return create(context as never, optionsWithDefault);
     }) as unknown,
     defaultOptions,


### PR DESCRIPTION
Added padding line between statements rule and improved code spacing

This PR introduces the `stylistic/padding-line-between-statements` ESLint rule with the following configurations:
- Requires blank lines after `const` and `let` declarations
- Allows consecutive `const` and `let` declarations without blank lines
- Requires blank lines before `return` statements

Additionally, added consistent blank lines in various files to improve code readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced linting configurations with a new rule that enforces consistent padding between statements.
  - Updated JavaScript lint settings with improved plugin integration and refined React configuration.

- **Chores**
  - Updated dependency versions to keep linting setups current.

- **Style**
  - Made several minor formatting adjustments for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->