### PR TITLE
🔧 Add "Merge queue" label to renovate config

### DIFF
--- a/packages/renovate/src/default.json
+++ b/packages/renovate/src/default.json
@@ -28,5 +28,6 @@
   "ignorePrAuthor": false,
   "prHourlyLimit": 0,
   "prCreation": "immediate",
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "addLabels": ["Merge queue"]
 }


### PR DESCRIPTION
Add "Merge queue" label to all pull requests by default

This PR adds the "Merge queue" label to all pull requests created by Renovate by updating the default configuration in `default.json`. This will allow PRs to be automatically added to the merge queue once they're approved.