### PR TITLE
🔧 Move ESLint to root-only configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
         run: pnpm install
 
       - name: 🧪 Test, lint, format, build, build and type-check
-        run: pnpm turbo run build test lint format types knip
+        run: pnpm turbo run build test lint:root format types knip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm install
 
       - name: 🧪 Test, lint, format, build, build and type-check
-        run: pnpm turbo run build test lint format types
+        run: pnpm turbo run build test lint:root format types
 
       - name: 🏗️ Build packages
         run: pnpm build --force

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,28 +3,19 @@ import { fileURLToPath } from 'node:url';
 
 import twoDigits from '@2digits/eslint-config';
 
-export default twoDigits(
-  {
-    ignores: {
-      gitIgnore: {
-        cwd: path.dirname(fileURLToPath(import.meta.url)),
-      },
-    },
-    react: true,
-    next: true,
-    tailwind: true,
-    storybook: true,
-    graphql: true,
-    tanstack: true,
-    turbo: true,
-    drizzle: true,
-    ts: true,
-  },
-  {
-    files: ['packages/eslint-config/typings/css-tree/index.d.ts'],
-    rules: {
-      '@2digits/type-param-names': 'off',
-      'ts/no-explicit-any': 'off',
+export default twoDigits({
+  ignores: {
+    gitIgnore: {
+      cwd: path.dirname(fileURLToPath(import.meta.url)),
     },
   },
-);
+  react: true,
+  next: true,
+  tailwind: true,
+  storybook: true,
+  graphql: true,
+  tanstack: true,
+  turbo: true,
+  drizzle: true,
+  ts: true,
+});

--- a/package.json
+++ b/package.json
@@ -5,16 +5,17 @@
   "type": "module",
   "scripts": {
     "build": "turbo run build",
-    "check": "turbo run --continue dependencies-successful test lint types format lint:pkg knip",
-    "check:watch": "turbo watch test lint types format lint:pkg",
+    "check": "turbo run --continue dependencies-successful test lint:root types format lint:pkg knip",
+    "check:watch": "turbo watch test lint:root types format lint:pkg",
     "clean": "find . -name node_modules -o -name .turbo -o -name dist -type d -prune | xargs rm -rf",
     "dev": "turbo run dev docs:dev",
     "docs": "turbo run docs",
     "fix": "pnpm '/(lint|format):fix$/'",
     "format": "prettier \"**/*\" --ignore-unknown --ignore-path .gitignore --ignore-path .prettierignore --check",
     "format:fix": "prettier \"**/*\" --ignore-unknown --ignore-path .gitignore --ignore-path .prettierignore --write",
-    "lint": "turbo run --continue dependencies-successful lint lint:pkg",
-    "lint:fix": "turbo run --continue dependencies-successful lint:pkg:fix lint -- --fix",
+    "lint": "turbo run --continue dependencies-successful lint:root lint:pkg",
+    "lint:fix": "turbo run --continue dependencies-successful lint:pkg:fix lint:root -- --fix",
+    "lint:root": "eslint .",
     "lint:pkg": "manypkg check",
     "lint:pkg:fix": "manypkg fix",
     "publish": "changeset publish",
@@ -41,7 +42,6 @@
     "typescript": "catalog:"
   },
   "packageManager": "pnpm@10.6.3",
-  "prettier": "@2digits/prettier-config",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",
@@ -76,5 +76,6 @@
       "string.prototype.repeat": "npm:@nolyfill/string.prototype.repeat@1.0.44",
       "which-typed-array": "npm:@nolyfill/which-typed-array@1.0.44"
     }
-  }
+  },
+  "prettier": "@2digits/prettier-config"
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -29,14 +29,12 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "lint": "eslint .",
     "types": "tsc --noEmit"
   },
   "license": "MIT",
   "public": true,
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
-    "eslint": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -31,7 +31,6 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "lint": "eslint .",
     "types": "tsc --noEmit",
     "docs": "eslint-config-inspector build",
     "docs:dev": "eslint-config-inspector"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "lint": "eslint .",
     "types": "tsc --noEmit",
     "test": "vitest --run"
   },

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -29,7 +29,6 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "lint": "eslint .",
     "types": "tsc --noEmit"
   },
   "keywords": [
@@ -51,7 +50,6 @@
   },
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
-    "eslint": "catalog:",
     "prettier": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:"

--- a/packages/renovate/package.json
+++ b/packages/renovate/package.json
@@ -9,7 +9,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "lint": "eslint .",
     "build": "node --experimental-strip-types build.ts",
     "test": "renovate-config-validator ./default.json ./src/*.json --strict",
     "types": "tsc --noEmit"
@@ -18,7 +17,6 @@
   "public": false,
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
-    "eslint": "catalog:",
     "nolyfill": "catalog:",
     "renovate": "catalog:",
     "typescript": "catalog:"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -16,9 +16,7 @@
     ".": "./tsconfig.json",
     "./tsconfig.json": "./tsconfig.json"
   },
-  "scripts": {
-    "lint": "eslint ."
-  },
+  "scripts": {},
   "keywords": [
     "tsconfig"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,9 +258,6 @@ importers:
       '@2digits/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      eslint:
-        specifier: 'catalog:'
-        version: 9.22.0(jiti@2.4.2)
       tsup:
         specifier: 'catalog:'
         version: 8.4.0(jiti@2.4.2)(postcss@8.4.40)(typescript@5.8.2)(yaml@2.7.0)
@@ -471,9 +468,6 @@ importers:
       '@2digits/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      eslint:
-        specifier: 'catalog:'
-        version: 9.22.0(jiti@2.4.2)
       prettier:
         specifier: 'catalog:'
         version: 3.5.3
@@ -489,9 +483,6 @@ importers:
       '@2digits/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      eslint:
-        specifier: 'catalog:'
-        version: 9.22.0(jiti@2.4.2)
       nolyfill:
         specifier: 'catalog:'
         version: 1.0.44

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalog:
   '@types/node': 22.13.10
   '@typescript-eslint/parser': 8.26.1
   '@typescript-eslint/utils': 8.26.1
+  eslint: 9.22.0
   eslint-config-flat-gitignore: 2.1.0
   eslint-config-prettier: 10.1.1
   eslint-flat-config-utils: 2.0.1
@@ -39,7 +40,6 @@ catalog:
   eslint-plugin-unicorn: 57.0.0
   eslint-typegen: 2.1.0
   eslint-vitest-rule-tester: 2.0.0
-  eslint: 9.22.0
   find-up: 7.0.0
   globals: 16.0.0
   graphql-config: 5.1.3
@@ -49,17 +49,17 @@ catalog:
   magic-regexp: 0.8.0
   nolyfill: 1.0.44
   pkg-pr-new: 0.0.41
+  prettier: 3.5.3
   prettier-plugin-embed: 0.5.0
   prettier-plugin-jsdoc: 1.3.2
   prettier-plugin-sh: 0.15.0
   prettier-plugin-sql: 0.18.1
   prettier-plugin-tailwindcss: 0.6.11
   prettier-plugin-toml: 2.0.2
-  prettier: 3.5.3
   renovate: 39.203.1
   ts-pattern: 5.6.2
   tsup: 8.4.0
   turbo: 2.4.4
-  typescript-eslint: 8.26.1
   typescript: 5.8.2
+  typescript-eslint: 8.26.1
   vitest: 3.0.8

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "globalPassThroughEnv": ["FORCE_COLOR"],
+  "globalPassThroughEnv": ["FORCE_COLOR", "COREPACK_HOME"],
   "ui": "tui",
   "tasks": {
     "build": {
@@ -16,7 +16,7 @@
     "dev": {
       "persistent": true
     },
-    "lint": {
+    "//#lint:root": {
       "dependsOn": ["@2digits/eslint-config#build"]
     },
     "//#lint:pkg": {


### PR DESCRIPTION
# Centralize ESLint Configuration to Root Level

This PR reorganizes our linting setup by:

1. Removing individual `lint` scripts from package.json files in all packages
2. Adding a new `lint:root` script in the root package.json that runs ESLint from the project root
3. Updating all references to the `lint` command in CI workflows and other scripts to use `lint:root` instead

This approach simplifies our linting process by running ESLint once from the root directory rather than separately in each package. It reduces duplication and ensures consistent linting across the entire codebase.

The PR also updates the turbo.json configuration to reflect this change by renaming the lint task to `#lint:root`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Streamlined continuous integration and build commands for testing, formatting, and code quality checks.
  - Consolidated linting configurations and optimized dependency management across the project.
  - Removed redundant linting scripts to enhance overall maintenance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->