### PR TITLE
🔧 Add eslint-plugin-yml for YAML linting

### DIFF
--- a/.changeset/moody-tables-unite.md
+++ b/.changeset/moody-tables-unite.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': minor
+---
+
+Added eslint-plugin-yml for yaml linting

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -70,12 +70,14 @@
     "eslint-plugin-tailwindcss": "catalog:",
     "eslint-plugin-turbo": "catalog:",
     "eslint-plugin-unicorn": "catalog:",
+    "eslint-plugin-yml": "catalog:",
     "find-up": "catalog:",
     "globals": "catalog:",
     "graphql-config": "catalog:",
     "jsonc-eslint-parser": "catalog:",
     "local-pkg": "catalog:",
-    "typescript-eslint": "catalog:"
+    "typescript-eslint": "catalog:",
+    "yaml-eslint-parser": "catalog:"
   },
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",

--- a/packages/eslint-config/src/configs/index.ts
+++ b/packages/eslint-config/src/configs/index.ts
@@ -20,3 +20,4 @@ export * from './tanstack';
 export * from './turbo';
 export * from './typescript';
 export * from './unicorn';
+export * from './yaml';

--- a/packages/eslint-config/src/configs/yaml.ts
+++ b/packages/eslint-config/src/configs/yaml.ts
@@ -1,0 +1,115 @@
+import yml from 'eslint-plugin-yml';
+import parser from 'yaml-eslint-parser';
+
+import { GLOB_YAML } from '../globs';
+import type { TypedFlatConfigItem } from '../types';
+
+export function yaml(): TypedFlatConfigItem[] {
+  return [
+    {
+      name: '2digits:yaml/setup',
+      plugins: {
+        yml,
+      },
+    },
+
+    {
+      name: '2digits:yaml/base',
+      ...SHARED_OPTIONS,
+      rules: {
+        'no-irregular-whitespace': 'off',
+        'no-unused-vars': 'off',
+        'spaced-comment': 'off',
+      },
+    },
+
+    {
+      name: '2digits:yaml/recommended',
+      ...SHARED_OPTIONS,
+      rules: {
+        'yml/no-empty-document': 'error',
+        'yml/no-empty-key': 'error',
+        'yml/no-empty-mapping-value': 'error',
+        'yml/no-empty-sequence-entry': 'error',
+        'yml/no-irregular-whitespace': 'error',
+        'yml/no-tab-indent': 'error',
+        'yml/vue-custom-block/no-parsing-error': 'error',
+      },
+    },
+
+    {
+      name: '2digits:yaml/standard',
+      ...SHARED_OPTIONS,
+      rules: {
+        'yml/block-mapping': 'error',
+        'yml/block-sequence': 'error',
+        'yml/plain-scalar': 'error',
+        'yml/spaced-comment': 'error',
+      },
+    },
+
+    {
+      name: '2digits:yaml/pnpm-workspace',
+      ...SHARED_OPTIONS,
+      files: ['pnpm-workspace.yaml'],
+      rules: {
+        'yml/sort-keys': [
+          'error',
+          {
+            order: [
+              'packages',
+              'overrides',
+              'patchedDependencies',
+              'hoistPattern',
+              'catalog',
+              'catalogs',
+
+              'allowedDeprecatedVersions',
+              'allowNonAppliedPatches',
+              'configDependencies',
+              'ignoredBuiltDependencies',
+              'ignoredOptionalDependencies',
+              'neverBuiltDependencies',
+              'onlyBuiltDependencies',
+              'onlyBuiltDependenciesFile',
+              'packageExtensions',
+              'peerDependencyRules',
+              'supportedArchitectures',
+            ],
+            pathPattern: '^$',
+          },
+          {
+            order: { type: 'asc' },
+            pathPattern: '.*',
+          },
+        ],
+      },
+    },
+
+    {
+      name: '2digits:yaml/prettier',
+      ...SHARED_OPTIONS,
+      rules: {
+        'yml/block-mapping-colon-indicator-newline': 'off',
+        'yml/block-mapping-question-indicator-newline': 'off',
+        'yml/block-sequence-hyphen-indicator-newline': 'off',
+        'yml/flow-mapping-curly-newline': 'off',
+        'yml/flow-mapping-curly-spacing': 'off',
+        'yml/flow-sequence-bracket-newline': 'off',
+        'yml/flow-sequence-bracket-spacing': 'off',
+        'yml/indent': 'off',
+        'yml/key-spacing': 'off',
+        'yml/no-multiple-empty-lines': 'off',
+        'yml/no-trailing-zeros': 'off',
+        'yml/quotes': 'off',
+      },
+    },
+  ];
+}
+
+const SHARED_OPTIONS = {
+  files: [GLOB_YAML],
+  languageOptions: {
+    parser,
+  },
+} satisfies Pick<TypedFlatConfigItem, 'languageOptions' | 'files'>;

--- a/packages/eslint-config/src/factory.ts
+++ b/packages/eslint-config/src/factory.ts
@@ -24,6 +24,7 @@ import {
   turbo,
   typescript,
   unicorn,
+  yaml,
 } from './configs';
 import { PluginNameMap } from './constants';
 import type {
@@ -91,6 +92,7 @@ export function twoDigits(
     antfu(),
     jsonc(),
     css(),
+    yaml(),
   );
 
   if (enabled(options.turbo, isPackageExists('turbo'))) {

--- a/packages/eslint-config/src/globs.ts
+++ b/packages/eslint-config/src/globs.ts
@@ -11,6 +11,8 @@ export const GLOB_JSONC = '**/*.jsonc';
 
 export const GLOB_CSS = '**/*.css';
 
+export const GLOB_YAML = '**/*.ya?ml';
+
 export const GLOB_EXCLUDE = [
   '**/node_modules',
   '**/dist',

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -7043,6 +7043,146 @@ Backward pagination arguments
    */
   'yield-star-spacing'?: Linter.RuleEntry<YieldStarSpacing>
   /**
+   * require or disallow block style mappings.
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping.html
+   */
+  'yml/block-mapping'?: Linter.RuleEntry<YmlBlockMapping>
+  /**
+   * enforce consistent line breaks after `:` indicator
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping-colon-indicator-newline.html
+   */
+  'yml/block-mapping-colon-indicator-newline'?: Linter.RuleEntry<YmlBlockMappingColonIndicatorNewline>
+  /**
+   * enforce consistent line breaks after `?` indicator
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping-question-indicator-newline.html
+   */
+  'yml/block-mapping-question-indicator-newline'?: Linter.RuleEntry<YmlBlockMappingQuestionIndicatorNewline>
+  /**
+   * require or disallow block style sequences.
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence.html
+   */
+  'yml/block-sequence'?: Linter.RuleEntry<YmlBlockSequence>
+  /**
+   * enforce consistent line breaks after `-` indicator
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence-hyphen-indicator-newline.html
+   */
+  'yml/block-sequence-hyphen-indicator-newline'?: Linter.RuleEntry<YmlBlockSequenceHyphenIndicatorNewline>
+  /**
+   * enforce YAML file extension
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/file-extension.html
+   */
+  'yml/file-extension'?: Linter.RuleEntry<YmlFileExtension>
+  /**
+   * enforce consistent line breaks inside braces
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-mapping-curly-newline.html
+   */
+  'yml/flow-mapping-curly-newline'?: Linter.RuleEntry<YmlFlowMappingCurlyNewline>
+  /**
+   * enforce consistent spacing inside braces
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-mapping-curly-spacing.html
+   */
+  'yml/flow-mapping-curly-spacing'?: Linter.RuleEntry<YmlFlowMappingCurlySpacing>
+  /**
+   * enforce linebreaks after opening and before closing flow sequence brackets
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-sequence-bracket-newline.html
+   */
+  'yml/flow-sequence-bracket-newline'?: Linter.RuleEntry<YmlFlowSequenceBracketNewline>
+  /**
+   * enforce consistent spacing inside flow sequence brackets
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-sequence-bracket-spacing.html
+   */
+  'yml/flow-sequence-bracket-spacing'?: Linter.RuleEntry<YmlFlowSequenceBracketSpacing>
+  /**
+   * enforce consistent indentation
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/indent.html
+   */
+  'yml/indent'?: Linter.RuleEntry<YmlIndent>
+  /**
+   * enforce naming convention to key names
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/key-name-casing.html
+   */
+  'yml/key-name-casing'?: Linter.RuleEntry<YmlKeyNameCasing>
+  /**
+   * enforce consistent spacing between keys and values in mapping pairs
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/key-spacing.html
+   */
+  'yml/key-spacing'?: Linter.RuleEntry<YmlKeySpacing>
+  /**
+   * disallow empty document
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-document.html
+   */
+  'yml/no-empty-document'?: Linter.RuleEntry<[]>
+  /**
+   * disallow empty mapping keys
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-key.html
+   */
+  'yml/no-empty-key'?: Linter.RuleEntry<[]>
+  /**
+   * disallow empty mapping values
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-mapping-value.html
+   */
+  'yml/no-empty-mapping-value'?: Linter.RuleEntry<[]>
+  /**
+   * disallow empty sequence entries
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-sequence-entry.html
+   */
+  'yml/no-empty-sequence-entry'?: Linter.RuleEntry<[]>
+  /**
+   * disallow irregular whitespace
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/no-irregular-whitespace.html
+   */
+  'yml/no-irregular-whitespace'?: Linter.RuleEntry<YmlNoIrregularWhitespace>
+  /**
+   * disallow multiple empty lines
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/no-multiple-empty-lines.html
+   */
+  'yml/no-multiple-empty-lines'?: Linter.RuleEntry<YmlNoMultipleEmptyLines>
+  /**
+   * disallow tabs for indentation.
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/no-tab-indent.html
+   */
+  'yml/no-tab-indent'?: Linter.RuleEntry<[]>
+  /**
+   * disallow trailing zeros for floats
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/no-trailing-zeros.html
+   */
+  'yml/no-trailing-zeros'?: Linter.RuleEntry<[]>
+  /**
+   * require or disallow plain style scalar.
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/plain-scalar.html
+   */
+  'yml/plain-scalar'?: Linter.RuleEntry<YmlPlainScalar>
+  /**
+   * enforce the consistent use of either double, or single quotes
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/quotes.html
+   */
+  'yml/quotes'?: Linter.RuleEntry<YmlQuotes>
+  /**
+   * disallow mapping keys other than strings
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/require-string-key.html
+   */
+  'yml/require-string-key'?: Linter.RuleEntry<[]>
+  /**
+   * require mapping keys to be sorted
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-keys.html
+   */
+  'yml/sort-keys'?: Linter.RuleEntry<YmlSortKeys>
+  /**
+   * require sequence values to be sorted
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-sequence-values.html
+   */
+  'yml/sort-sequence-values'?: Linter.RuleEntry<YmlSortSequenceValues>
+  /**
+   * enforce consistent spacing after the `#` in a comment
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/spaced-comment.html
+   */
+  'yml/spaced-comment'?: Linter.RuleEntry<YmlSpacedComment>
+  /**
+   * disallow parsing errors in Vue custom blocks
+   * @see https://ota-meshi.github.io/eslint-plugin-yml/rules/vue-custom-block/no-parsing-error.html
+   */
+  'yml/vue-custom-block/no-parsing-error'?: Linter.RuleEntry<[]>
+  /**
    * Require or disallow "Yoda" conditions
    * @see https://eslint.org/docs/latest/rules/yoda
    */
@@ -12805,10 +12945,217 @@ type YieldStarSpacing = []|[(("before" | "after" | "both" | "neither") | {
   before?: boolean
   after?: boolean
 })]
+// ----- yml/block-mapping -----
+type YmlBlockMapping = []|[(("always" | "never") | {
+  singleline?: ("always" | "never" | "ignore")
+  multiline?: ("always" | "never" | "ignore")
+})]
+// ----- yml/block-mapping-colon-indicator-newline -----
+type YmlBlockMappingColonIndicatorNewline = []|[("always" | "never")]
+// ----- yml/block-mapping-question-indicator-newline -----
+type YmlBlockMappingQuestionIndicatorNewline = []|[("always" | "never")]
+// ----- yml/block-sequence -----
+type YmlBlockSequence = []|[(("always" | "never") | {
+  singleline?: ("always" | "never" | "ignore")
+  multiline?: ("always" | "never" | "ignore")
+})]
+// ----- yml/block-sequence-hyphen-indicator-newline -----
+type YmlBlockSequenceHyphenIndicatorNewline = []|[("always" | "never")]|[("always" | "never"), {
+  nestedHyphen?: ("always" | "never")
+  blockMapping?: ("always" | "never")
+}]
+// ----- yml/file-extension -----
+type YmlFileExtension = []|[{
+  extension?: ("yaml" | "yml")
+  caseSensitive?: boolean
+}]
+// ----- yml/flow-mapping-curly-newline -----
+type YmlFlowMappingCurlyNewline = []|[(("always" | "never") | {
+  multiline?: boolean
+  minProperties?: number
+  consistent?: boolean
+})]
+// ----- yml/flow-mapping-curly-spacing -----
+type YmlFlowMappingCurlySpacing = []|[("always" | "never")]|[("always" | "never"), {
+  arraysInObjects?: boolean
+  objectsInObjects?: boolean
+}]
+// ----- yml/flow-sequence-bracket-newline -----
+type YmlFlowSequenceBracketNewline = []|[(("always" | "never" | "consistent") | {
+  multiline?: boolean
+  minItems?: (number | null)
+})]
+// ----- yml/flow-sequence-bracket-spacing -----
+type YmlFlowSequenceBracketSpacing = []|[("always" | "never")]|[("always" | "never"), {
+  singleValue?: boolean
+  objectsInArrays?: boolean
+  arraysInArrays?: boolean
+}]
+// ----- yml/indent -----
+type YmlIndent = []|[number]|[number, {
+  indentBlockSequences?: boolean
+  indicatorValueIndent?: number
+}]
+// ----- yml/key-name-casing -----
+type YmlKeyNameCasing = []|[{
+  camelCase?: boolean
+  PascalCase?: boolean
+  SCREAMING_SNAKE_CASE?: boolean
+  "kebab-case"?: boolean
+  snake_case?: boolean
+  ignores?: string[]
+}]
+// ----- yml/key-spacing -----
+type YmlKeySpacing = []|[({
+  align?: (("colon" | "value") | {
+    on?: ("colon" | "value")
+    mode?: ("strict" | "minimum")
+    beforeColon?: boolean
+    afterColon?: boolean
+  })
+  mode?: ("strict" | "minimum")
+  beforeColon?: boolean
+  afterColon?: boolean
+} | {
+  singleLine?: {
+    mode?: ("strict" | "minimum")
+    beforeColon?: boolean
+    afterColon?: boolean
+  }
+  multiLine?: {
+    align?: (("colon" | "value") | {
+      on?: ("colon" | "value")
+      mode?: ("strict" | "minimum")
+      beforeColon?: boolean
+      afterColon?: boolean
+    })
+    mode?: ("strict" | "minimum")
+    beforeColon?: boolean
+    afterColon?: boolean
+  }
+} | {
+  singleLine?: {
+    mode?: ("strict" | "minimum")
+    beforeColon?: boolean
+    afterColon?: boolean
+  }
+  multiLine?: {
+    mode?: ("strict" | "minimum")
+    beforeColon?: boolean
+    afterColon?: boolean
+  }
+  align?: {
+    on?: ("colon" | "value")
+    mode?: ("strict" | "minimum")
+    beforeColon?: boolean
+    afterColon?: boolean
+  }
+})]
+// ----- yml/no-irregular-whitespace -----
+type YmlNoIrregularWhitespace = []|[{
+  skipComments?: boolean
+  skipQuotedScalars?: boolean
+}]
+// ----- yml/no-multiple-empty-lines -----
+type YmlNoMultipleEmptyLines = []|[{
+  max: number
+  maxEOF?: number
+  maxBOF?: number
+}]
+// ----- yml/plain-scalar -----
+type YmlPlainScalar = []|[("always" | "never")]|[("always" | "never"), {
+  ignorePatterns?: string[]
+  overrides?: {
+    mappingKey?: ("always" | "never" | null)
+  }
+}]
+// ----- yml/quotes -----
+type YmlQuotes = []|[{
+  prefer?: ("double" | "single")
+  avoidEscape?: boolean
+}]
+// ----- yml/sort-keys -----
+type YmlSortKeys = ([{
+  pathPattern: string
+  hasProperties?: string[]
+  order: ((string | {
+    keyPattern?: string
+    order?: {
+      type?: ("asc" | "desc")
+      caseSensitive?: boolean
+      natural?: boolean
+    }
+  })[] | {
+    type?: ("asc" | "desc")
+    caseSensitive?: boolean
+    natural?: boolean
+  })
+  minKeys?: number
+  allowLineSeparatedGroups?: boolean
+}, ...({
+  pathPattern: string
+  hasProperties?: string[]
+  order: ((string | {
+    keyPattern?: string
+    order?: {
+      type?: ("asc" | "desc")
+      caseSensitive?: boolean
+      natural?: boolean
+    }
+  })[] | {
+    type?: ("asc" | "desc")
+    caseSensitive?: boolean
+    natural?: boolean
+  })
+  minKeys?: number
+  allowLineSeparatedGroups?: boolean
+})[]] | []|[("asc" | "desc")]|[("asc" | "desc"), {
+  caseSensitive?: boolean
+  natural?: boolean
+  minKeys?: number
+  allowLineSeparatedGroups?: boolean
+}])
+// ----- yml/sort-sequence-values -----
+type YmlSortSequenceValues = [{
+  pathPattern: string
+  order: ((string | {
+    valuePattern?: string
+    order?: {
+      type?: ("asc" | "desc")
+      caseSensitive?: boolean
+      natural?: boolean
+    }
+  })[] | {
+    type?: ("asc" | "desc")
+    caseSensitive?: boolean
+    natural?: boolean
+  })
+  minValues?: number
+}, ...({
+  pathPattern: string
+  order: ((string | {
+    valuePattern?: string
+    order?: {
+      type?: ("asc" | "desc")
+      caseSensitive?: boolean
+      natural?: boolean
+    }
+  })[] | {
+    type?: ("asc" | "desc")
+    caseSensitive?: boolean
+    natural?: boolean
+  })
+  minValues?: number
+})[]]
+// ----- yml/spaced-comment -----
+type YmlSpacedComment = []|[("always" | "never")]|[("always" | "never"), {
+  exceptions?: string[]
+  markers?: string[]
+}]
 // ----- yoda -----
 type Yoda = []|[("always" | "never")]|[("always" | "never"), {
   exceptRange?: boolean
   onlyEquality?: boolean
 }]
 // Names of all the configs
-export type ConfigNames = '2digits:antfu' | '2digits:boolean' | '2digits:comments' | '2digits:css' | '2digits:drizzle' | '2digits:graphql' | '2digits:ignores' | '2digits:gitignore' | '2digits:javascript' | '2digits:jsdoc' | '2digits:jsonc/base' | '2digits:jsonc/base' | '2digits:jsonc/json' | '2digits:jsonc/jsonc' | '2digits:jsonc/json5' | '2digits:jsonc/package.json' | '2digits:jsonc/tsconfig.json' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:next/setup' | '2digits:next/rules' | '2digits:node' | '2digits:prettier' | '2digits:react/setup' | '2digits:react/rules' | '2digits:regexp' | '2digits:sonar' | '2digits:storybook/setup' | '2digits:storybook/rules' | '2digits:storybook/disables' | '2digits:storybook/config' | '2digits:tailwind' | '2digits:tanstack' | '2digits:turbo' | '2digits:typescript/setup' | '2digits:typescript/rules' | '2digits:typescript/disables/dts' | '2digits:typescript/disables/test' | '2digits:typescript/disables/cjs' | '2digits:unicorn'
+export type ConfigNames = '2digits:antfu' | '2digits:boolean' | '2digits:comments' | '2digits:css' | '2digits:drizzle' | '2digits:graphql' | '2digits:ignores' | '2digits:gitignore' | '2digits:javascript' | '2digits:jsdoc' | '2digits:jsonc/base' | '2digits:jsonc/base' | '2digits:jsonc/json' | '2digits:jsonc/jsonc' | '2digits:jsonc/json5' | '2digits:jsonc/package.json' | '2digits:jsonc/tsconfig.json' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:next/setup' | '2digits:next/rules' | '2digits:node' | '2digits:prettier' | '2digits:react/setup' | '2digits:react/rules' | '2digits:regexp' | '2digits:sonar' | '2digits:storybook/setup' | '2digits:storybook/rules' | '2digits:storybook/disables' | '2digits:storybook/config' | '2digits:tailwind' | '2digits:tanstack' | '2digits:turbo' | '2digits:typescript/setup' | '2digits:typescript/rules' | '2digits:typescript/disables/dts' | '2digits:typescript/disables/test' | '2digits:typescript/disables/cjs' | '2digits:unicorn' | '2digits:yaml/setup' | '2digits:yaml/base' | '2digits:yaml/recommended' | '2digits:yaml/standard' | '2digits:yaml/pnpm-workspace' | '2digits:yaml/prettier'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ catalogs:
     eslint-plugin-unicorn:
       specifier: 57.0.0
       version: 57.0.0
+    eslint-plugin-yml:
+      specifier: 1.17.0
+      version: 1.17.0
     eslint-typegen:
       specifier: 2.1.0
       version: 2.1.0
@@ -186,6 +189,9 @@ catalogs:
     vitest:
       specifier: 3.0.8
       version: 3.0.8
+    yaml-eslint-parser:
+      specifier: 1.3.0
+      version: 1.3.0
 
 overrides:
   array-includes: npm:@nolyfill/array-includes@1.0.44
@@ -354,6 +360,9 @@ importers:
       eslint-plugin-unicorn:
         specifier: 'catalog:'
         version: 57.0.0(eslint@9.22.0(jiti@2.4.2))
+      eslint-plugin-yml:
+        specifier: 'catalog:'
+        version: 1.17.0(eslint@9.22.0(jiti@2.4.2))
       find-up:
         specifier: 'catalog:'
         version: 7.0.0
@@ -372,6 +381,9 @@ importers:
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      yaml-eslint-parser:
+        specifier: 'catalog:'
+        version: 1.3.0
     devDependencies:
       '@2digits/tsconfig':
         specifier: workspace:*
@@ -3416,6 +3428,12 @@ packages:
     peerDependencies:
       eslint: '>=9.20.0'
 
+  eslint-plugin-yml@1.17.0:
+    resolution: {integrity: sha512-Q3LXFRnNpGYAK/PM0BY1Xs0IY1xTLfM0kC986nNQkx1l8tOGz+YS50N6wXkAJkrBpeUN9OxEMB7QJ+9MTDAqIQ==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=6.0.0'
+
   eslint-scope@8.3.0:
     resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -6121,6 +6139,10 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml-eslint-parser@1.3.0:
+    resolution: {integrity: sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==}
+    engines: {node: ^14.17.0 || >=16.0.0}
 
   yaml@2.7.0:
     resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
@@ -10114,6 +10136,17 @@ snapshots:
       semver: 7.7.1
       strip-indent: 4.0.0
 
+  eslint-plugin-yml@1.17.0(eslint@9.22.0(jiti@2.4.2)):
+    dependencies:
+      debug: 4.4.0
+      escape-string-regexp: 4.0.0
+      eslint: 9.22.0(jiti@2.4.2)
+      eslint-compat-utils: 0.6.4(eslint@9.22.0(jiti@2.4.2))
+      natural-compare: 1.4.0
+      yaml-eslint-parser: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-scope@8.3.0:
     dependencies:
       esrecurse: 4.3.0
@@ -13127,6 +13160,11 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml-eslint-parser@1.3.0:
+    dependencies:
+      eslint-visitor-keys: 3.4.3
+      yaml: 2.7.0
 
   yaml@2.7.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ catalog:
   eslint-plugin-tailwindcss: 3.18.0
   eslint-plugin-turbo: 2.4.4
   eslint-plugin-unicorn: 57.0.0
+  eslint-plugin-yml: 1.17.0
   eslint-typegen: 2.1.0
   eslint-vitest-rule-tester: 2.0.0
   find-up: 7.0.0
@@ -63,3 +64,4 @@ catalog:
   typescript: 5.8.2
   typescript-eslint: 8.26.1
   vitest: 3.0.8
+  yaml-eslint-parser: 1.3.0


### PR DESCRIPTION
# Added YAML Linting Support with eslint-plugin-yml

This PR adds YAML linting capabilities to our ESLint configuration by integrating `eslint-plugin-yml` and `yaml-eslint-parser`. The implementation includes:

- Configuration for YAML files with glob pattern support (`**/*.ya?ml`)
- Multiple rule sets:
  - Base rules that disable conflicting ESLint rules
  - Recommended rules for error prevention
  - Standard rules for consistent formatting
  - Special rules for `pnpm-workspace.yaml` with sorted keys
  - Prettier compatibility rules

The YAML linting is automatically enabled in the default configuration, providing immediate benefits without requiring additional setup.

A changeset has been added to mark this as a minor version update to `@2digits/eslint-config`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated comprehensive YAML linting into the configuration, including dedicated plugin and parser support.
  - Extended linting rules to enforce best practices for YAML files, covering formatting, indentation, and key naming conventions for improved code quality.
  - Introduced new export options for YAML configurations and added support for various YAML linting scenarios. 

- **Chores**
  - Updated package dependencies to include new YAML linting tools in the workspace configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->