### PR TITLE
🔧 Add eslint-plugin-pnpm for linting pnpm monorepos

### DIFF
--- a/.changeset/floppy-dragons-ask.md
+++ b/.changeset/floppy-dragons-ask.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': minor
+---
+
+Added eslint-plugin-pnpm for linting pnpm monorepos

--- a/package.json
+++ b/package.json
@@ -42,40 +42,5 @@
     "typescript": "catalog:"
   },
   "packageManager": "pnpm@10.6.3",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "better-sqlite3",
-      "core-js-pure",
-      "dtrace-provider",
-      "protobufjs",
-      "re2"
-    ],
-    "overrides": {
-      "array-includes": "npm:@nolyfill/array-includes@1.0.44",
-      "array.prototype.findlast": "npm:@nolyfill/array.prototype.findlast@1.0.44",
-      "array.prototype.flat": "npm:@nolyfill/array.prototype.flat@1.0.44",
-      "array.prototype.flatmap": "npm:@nolyfill/array.prototype.flatmap@1.0.44",
-      "array.prototype.tosorted": "npm:@nolyfill/array.prototype.tosorted@1.0.44",
-      "es-iterator-helpers": "npm:@nolyfill/es-iterator-helpers@1.0.21",
-      "globalthis": "npm:@nolyfill/globalthis@1.0.44",
-      "hasown": "npm:@nolyfill/hasown@1.0.44",
-      "is-arguments": "npm:@nolyfill/is-arguments@1.0.44",
-      "is-core-module": "npm:@nolyfill/is-core-module@1.0.39",
-      "is-generator-function": "npm:@nolyfill/is-generator-function@1.0.44",
-      "is-typed-array": "npm:@nolyfill/is-typed-array@1.0.44",
-      "isarray": "npm:@nolyfill/isarray@1.0.44",
-      "object.assign": "npm:@nolyfill/object.assign@1.0.44",
-      "object.entries": "npm:@nolyfill/object.entries@1.0.44",
-      "object.fromentries": "npm:@nolyfill/object.fromentries@1.0.44",
-      "object.values": "npm:@nolyfill/object.values@1.0.44",
-      "safe-buffer": "npm:@nolyfill/safe-buffer@1.0.44",
-      "safer-buffer": "npm:@nolyfill/safer-buffer@1.0.44",
-      "side-channel": "npm:@nolyfill/side-channel@1.0.44",
-      "string.prototype.matchall": "npm:@nolyfill/string.prototype.matchall@1.0.44",
-      "string.prototype.repeat": "npm:@nolyfill/string.prototype.repeat@1.0.44",
-      "which-typed-array": "npm:@nolyfill/which-typed-array@1.0.44"
-    }
-  },
   "prettier": "@2digits/prettier-config"
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-jsdoc": "catalog:",
     "eslint-plugin-jsonc": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-pnpm": "catalog:",
     "eslint-plugin-react-compiler": "catalog:",
     "eslint-plugin-react-hooks": "catalog:",
     "eslint-plugin-regexp": "catalog:",

--- a/packages/eslint-config/src/configs/index.ts
+++ b/packages/eslint-config/src/configs/index.ts
@@ -10,6 +10,7 @@ export * from './jsdoc';
 export * from './jsonc';
 export * from './next';
 export * from './node';
+export * from './pnpm';
 export * from './prettier';
 export * from './react';
 export * from './regexp';

--- a/packages/eslint-config/src/configs/pnpm.ts
+++ b/packages/eslint-config/src/configs/pnpm.ts
@@ -1,0 +1,41 @@
+import jsoncParser from 'jsonc-eslint-parser';
+import yamlParser from 'yaml-eslint-parser';
+
+import type { TypedFlatConfigItem } from '../types';
+import { interopDefault } from '../utils';
+
+export async function pnpm(): Promise<TypedFlatConfigItem[]> {
+  const plugin = await interopDefault(import('eslint-plugin-pnpm'));
+
+  return [
+    {
+      name: '2digits:pnpm/package-json',
+      files: ['**/package.json'],
+      languageOptions: {
+        parser: jsoncParser,
+      },
+      plugins: {
+        pnpm: plugin,
+      },
+      rules: {
+        'pnpm/json-enforce-catalog': 'error',
+        'pnpm/json-prefer-workspace-settings': 'error',
+        'pnpm/json-valid-catalog': 'error',
+      },
+    },
+    {
+      name: '2digits:pnpm/pnpm-workspace-yaml',
+      files: ['pnpm-workspace.yaml'],
+      languageOptions: {
+        parser: yamlParser,
+      },
+      plugins: {
+        pnpm: plugin,
+      },
+      rules: {
+        'pnpm/yaml-no-duplicate-catalog-item': 'error',
+        'pnpm/yaml-no-unused-catalog-item': 'error',
+      },
+    },
+  ];
+}

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -2646,6 +2646,31 @@ Backward pagination arguments
    */
   'padding-line-between-statements'?: Linter.RuleEntry<PaddingLineBetweenStatements>
   /**
+   * Enforce using "catalog:" in `package.json`
+   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/json-enforce-catalog.test.ts
+   */
+  'pnpm/json-enforce-catalog'?: Linter.RuleEntry<PnpmJsonEnforceCatalog>
+  /**
+   * Prefer having pnpm settings in `pnpm-workspace.yaml` instead of `package.json`. This would requires pnpm v10.6+, see https://github.com/orgs/pnpm/discussions/9037.
+   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/json-prefer-workspace-settings.test.ts
+   */
+  'pnpm/json-prefer-workspace-settings'?: Linter.RuleEntry<PnpmJsonPreferWorkspaceSettings>
+  /**
+   * Enforce using valid catalog in `package.json`
+   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/json-valid-catalog.test.ts
+   */
+  'pnpm/json-valid-catalog'?: Linter.RuleEntry<PnpmJsonValidCatalog>
+  /**
+   * Disallow unused catalogs in `pnpm-workspace.yaml`
+   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/yaml-no-duplicate-catalog-item.test.ts
+   */
+  'pnpm/yaml-no-duplicate-catalog-item'?: Linter.RuleEntry<PnpmYamlNoDuplicateCatalogItem>
+  /**
+   * Disallow unused catalogs in `pnpm-workspace.yaml`
+   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/yaml-no-unused-catalog-item.test.ts
+   */
+  'pnpm/yaml-no-unused-catalog-item'?: Linter.RuleEntry<[]>
+  /**
    * Require using arrow functions for callbacks
    * @see https://eslint.org/docs/latest/rules/prefer-arrow-callback
    */
@@ -9728,6 +9753,43 @@ type PaddingLineBetweenStatements = {
   prev: _PaddingLineBetweenStatementsStatementType
   next: _PaddingLineBetweenStatementsStatementType
 }[]
+// ----- pnpm/json-enforce-catalog -----
+type PnpmJsonEnforceCatalog = []|[{
+  
+  allowedProtocols?: string[]
+  
+  autofix?: boolean
+  
+  defaultCatalog?: string
+  
+  reuseExistingCatalog?: boolean
+  
+  conflicts?: ("new-catalog" | "overrides" | "error")
+  
+  fields?: string[]
+}]
+// ----- pnpm/json-prefer-workspace-settings -----
+type PnpmJsonPreferWorkspaceSettings = []|[{
+  
+  autofix?: boolean
+}]
+// ----- pnpm/json-valid-catalog -----
+type PnpmJsonValidCatalog = []|[{
+  
+  autoInsert?: boolean
+  
+  autoInsertDefaultSpecifier?: string
+  
+  autofix?: boolean
+  
+  enforceNoConflict?: boolean
+  
+  fields?: unknown[]
+}]
+// ----- pnpm/yaml-no-duplicate-catalog-item -----
+type PnpmYamlNoDuplicateCatalogItem = []|[{
+  allow?: string[]
+}]
 // ----- prefer-arrow-callback -----
 type PreferArrowCallback = []|[{
   allowNamedFunctions?: boolean
@@ -13158,4 +13220,4 @@ type Yoda = []|[("always" | "never")]|[("always" | "never"), {
   onlyEquality?: boolean
 }]
 // Names of all the configs
-export type ConfigNames = '2digits:antfu' | '2digits:boolean' | '2digits:comments' | '2digits:css' | '2digits:drizzle' | '2digits:graphql' | '2digits:ignores' | '2digits:gitignore' | '2digits:javascript' | '2digits:jsdoc' | '2digits:jsonc/base' | '2digits:jsonc/base' | '2digits:jsonc/json' | '2digits:jsonc/jsonc' | '2digits:jsonc/json5' | '2digits:jsonc/package.json' | '2digits:jsonc/tsconfig.json' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:next/setup' | '2digits:next/rules' | '2digits:node' | '2digits:prettier' | '2digits:react/setup' | '2digits:react/rules' | '2digits:regexp' | '2digits:sonar' | '2digits:storybook/setup' | '2digits:storybook/rules' | '2digits:storybook/disables' | '2digits:storybook/config' | '2digits:tailwind' | '2digits:tanstack' | '2digits:turbo' | '2digits:typescript/setup' | '2digits:typescript/rules' | '2digits:typescript/disables/dts' | '2digits:typescript/disables/test' | '2digits:typescript/disables/cjs' | '2digits:unicorn' | '2digits:yaml/setup' | '2digits:yaml/base' | '2digits:yaml/recommended' | '2digits:yaml/standard' | '2digits:yaml/pnpm-workspace' | '2digits:yaml/prettier'
+export type ConfigNames = '2digits:antfu' | '2digits:boolean' | '2digits:comments' | '2digits:css' | '2digits:drizzle' | '2digits:graphql' | '2digits:ignores' | '2digits:gitignore' | '2digits:javascript' | '2digits:jsdoc' | '2digits:jsonc/base' | '2digits:jsonc/base' | '2digits:jsonc/json' | '2digits:jsonc/jsonc' | '2digits:jsonc/json5' | '2digits:jsonc/package.json' | '2digits:jsonc/tsconfig.json' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:next/setup' | '2digits:next/rules' | '2digits:node' | '2digits:pnpm/package-json' | '2digits:pnpm/pnpm-workspace-yaml' | '2digits:prettier' | '2digits:react/setup' | '2digits:react/rules' | '2digits:regexp' | '2digits:sonar' | '2digits:storybook/setup' | '2digits:storybook/rules' | '2digits:storybook/disables' | '2digits:storybook/config' | '2digits:tailwind' | '2digits:tanstack' | '2digits:turbo' | '2digits:typescript/setup' | '2digits:typescript/rules' | '2digits:typescript/disables/dts' | '2digits:typescript/disables/test' | '2digits:typescript/disables/cjs' | '2digits:unicorn' | '2digits:yaml/setup' | '2digits:yaml/base' | '2digits:yaml/recommended' | '2digits:yaml/standard' | '2digits:yaml/pnpm-workspace' | '2digits:yaml/prettier'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ catalogs:
     eslint-plugin-n:
       specifier: 17.16.2
       version: 17.16.2
+    eslint-plugin-pnpm:
+      specifier: 0.3.1
+      version: 0.3.1
     eslint-plugin-react-compiler:
       specifier: 19.0.0-beta-e552027-20250112
       version: 19.0.0-beta-e552027-20250112
@@ -336,6 +339,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 17.16.2(eslint@9.22.0(jiti@2.4.2))
+      eslint-plugin-pnpm:
+        specifier: 'catalog:'
+        version: 0.3.1(eslint@9.22.0(jiti@2.4.2))
       eslint-plugin-react-compiler:
         specifier: 'catalog:'
         version: 19.0.0-beta-e552027-20250112(eslint@9.22.0(jiti@2.4.2))
@@ -3317,6 +3323,11 @@ packages:
     peerDependencies:
       eslint: '>=8.23.0'
 
+  eslint-plugin-pnpm@0.3.1:
+    resolution: {integrity: sha512-vi5iHoELIAlBbX4AW8ZGzU3tUnfxuXhC/NKo3qRcI5o9igbz6zJUqSlQ03bPeMqWIGTPatZnbWsNR1RnlNERNQ==}
+    peerDependencies:
+      eslint: ^9.0.0
+
   eslint-plugin-react-compiler@19.0.0-beta-e552027-20250112:
     resolution: {integrity: sha512-VjkIXHouCYyJHgk5HmZ1LH+fAK5CX+ULRX9iNYtwYJ+ljbivFhIT+JJyxNT/USQpCeS2Dt5ahjFeeMv0RRwTww==}
     engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
@@ -3597,6 +3608,10 @@ packages:
 
   find-up-simple@1.0.0:
     resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
+    engines: {node: '>=18'}
+
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
 
   find-up@4.1.0:
@@ -4902,6 +4917,9 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  pnpm-workspace-yaml@0.3.1:
+    resolution: {integrity: sha512-3nW5RLmREmZ8Pm8MbPsO2RM+99RRjYd25ynj3NV0cFsN7CcEl4sDFzgoFmSyduFwxFQ2Qbu3y2UdCh6HlyUOeA==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -9933,6 +9951,16 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.7.1
 
+  eslint-plugin-pnpm@0.3.1(eslint@9.22.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.22.0(jiti@2.4.2)
+      find-up-simple: 1.0.1
+      jsonc-eslint-parser: 2.4.0
+      pathe: 2.0.3
+      pnpm-workspace-yaml: 0.3.1
+      tinyglobby: 0.2.12
+      yaml-eslint-parser: 1.3.0
+
   eslint-plugin-react-compiler@19.0.0-beta-e552027-20250112(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
       '@babel/core': 7.25.2
@@ -10344,6 +10372,8 @@ snapshots:
       p-filter: 2.1.0
 
   find-up-simple@1.0.0: {}
+
+  find-up-simple@1.0.1: {}
 
   find-up@4.1.0:
     dependencies:
@@ -11799,6 +11829,10 @@ snapshots:
       pathe: 2.0.3
 
   pluralize@8.0.0: {}
+
+  pnpm-workspace-yaml@0.3.1:
+    dependencies:
+      yaml: 2.7.0
 
   postcss-import@15.1.0(postcss@8.4.40):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,29 @@
-verifyDepsBeforeRun: install
-savePrefix: ''
 packages:
   - packages/*
+overrides:
+  array-includes: npm:@nolyfill/array-includes@1.0.44
+  array.prototype.findlast: npm:@nolyfill/array.prototype.findlast@1.0.44
+  array.prototype.flat: npm:@nolyfill/array.prototype.flat@1.0.44
+  array.prototype.flatmap: npm:@nolyfill/array.prototype.flatmap@1.0.44
+  array.prototype.tosorted: npm:@nolyfill/array.prototype.tosorted@1.0.44
+  es-iterator-helpers: npm:@nolyfill/es-iterator-helpers@1.0.21
+  globalthis: npm:@nolyfill/globalthis@1.0.44
+  hasown: npm:@nolyfill/hasown@1.0.44
+  is-arguments: npm:@nolyfill/is-arguments@1.0.44
+  is-core-module: npm:@nolyfill/is-core-module@1.0.39
+  is-generator-function: npm:@nolyfill/is-generator-function@1.0.44
+  is-typed-array: npm:@nolyfill/is-typed-array@1.0.44
+  isarray: npm:@nolyfill/isarray@1.0.44
+  object.assign: npm:@nolyfill/object.assign@1.0.44
+  object.entries: npm:@nolyfill/object.entries@1.0.44
+  object.fromentries: npm:@nolyfill/object.fromentries@1.0.44
+  object.values: npm:@nolyfill/object.values@1.0.44
+  safe-buffer: npm:@nolyfill/safe-buffer@1.0.44
+  safer-buffer: npm:@nolyfill/safer-buffer@1.0.44
+  side-channel: npm:@nolyfill/side-channel@1.0.44
+  string.prototype.matchall: npm:@nolyfill/string.prototype.matchall@1.0.44
+  string.prototype.repeat: npm:@nolyfill/string.prototype.repeat@1.0.44
+  which-typed-array: npm:@nolyfill/which-typed-array@1.0.44
 catalog:
   '@changesets/cli': 2.28.1
   '@eslint-community/eslint-plugin-eslint-comments': 4.4.1
@@ -30,6 +52,7 @@ catalog:
   eslint-plugin-jsdoc: 50.6.6
   eslint-plugin-jsonc: 2.19.1
   eslint-plugin-n: 17.16.2
+  eslint-plugin-pnpm: 0.3.1
   eslint-plugin-react-compiler: 19.0.0-beta-e552027-20250112
   eslint-plugin-react-hooks: 5.2.0
   eslint-plugin-regexp: 2.7.0
@@ -65,3 +88,12 @@ catalog:
   typescript-eslint: 8.26.1
   vitest: 3.0.8
   yaml-eslint-parser: 1.3.0
+onlyBuiltDependencies:
+  - esbuild
+  - better-sqlite3
+  - core-js-pure
+  - dtrace-provider
+  - protobufjs
+  - re2
+verifyDepsBeforeRun: install
+savePrefix: ''


### PR DESCRIPTION
# Add ESLint plugin for pnpm monorepos

This PR adds support for linting pnpm monorepos by integrating `eslint-plugin-pnpm`. The plugin provides rules for validating and enforcing best practices in pnpm workspaces.

Key changes:
- Added `eslint-plugin-pnpm` as a dependency
- Created a new pnpm config module with rules for:
  - Enforcing catalog usage in package.json files
  - Validating catalog entries
  - Preferring workspace settings in pnpm-workspace.yaml
  - Detecting duplicate or unused catalog items

The ESLint config will now automatically detect pnpm workspaces by looking for a `pnpm-workspace.yaml` file and enable the appropriate rules.

As part of this change, we've also moved pnpm settings from package.json to pnpm-workspace.yaml, following best practices for pnpm v10.6+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced ESLint support for pnpm monorepos with new linting rules that help validate package and workspace configurations, ensuring catalog integrity and proper dependency management.
  - Added a new `overrides` section and `onlyBuiltDependencies` in the pnpm workspace configuration for enhanced dependency management.

- **Chores**
  - Removed legacy pnpm configuration from the main setup for a cleaner configuration structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->