### PR TITLE
🐛 Fix YAML linting rules for yml files

### DIFF
--- a/.changeset/tired-doors-fetch.md
+++ b/.changeset/tired-doors-fetch.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Fixed yaml linting rules not applying to yml files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,10 @@ concurrency:
 on:
   push:
     branches:
-      - 'main'
+      - main
   merge_group:
+    types:
+      - checks_requested
   pull_request:
     types:
       - synchronize

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   push:
     branches:
-      - 'main'
+      - main
 
 jobs:
   publish:

--- a/packages/eslint-config/src/globs.ts
+++ b/packages/eslint-config/src/globs.ts
@@ -11,7 +11,7 @@ export const GLOB_JSONC = '**/*.jsonc';
 
 export const GLOB_CSS = '**/*.css';
 
-export const GLOB_YAML = '**/*.ya?ml';
+export const GLOB_YAML = '**/*.y?(a)ml';
 
 export const GLOB_MARKDOWN = '**/*.md';
 export const GLOB_MARKDOWN_IN_MARKDOWN = '**/*.md/*.md';
@@ -24,6 +24,7 @@ export const GLOB_EXCLUDE = [
   '**/yarn.lock',
   '**/pnpm-lock.yaml',
   '**/bun.lockb',
+  '**/bun.lock',
 
   '**/output',
   '**/coverage',


### PR DESCRIPTION
# Fix YAML linting rules for .yml files and update GitHub workflow configurations

This PR addresses an issue where YAML linting rules were not being applied to `.yml` files, only to `.yaml` files. The fix updates the glob pattern for YAML files to properly match both extensions.

Changes include:
- Updated `GLOB_YAML` pattern from `'**/*.ya?ml'` to `'**/*.y?(a)ml'` to correctly match both `.yml` and `.yaml` files
- Added `'**/bun.lock'` to the excluded files list
- Improved GitHub workflow configurations:
  - Simplified branch name format in workflow files (removed unnecessary quotes)
  - Added `types: [checks_requested]` to the merge group trigger in CI workflow

These changes ensure consistent linting across all YAML files regardless of extension.