### PR TITLE
🔧 Fix TypeScript rules linting markdown snippets

### DIFF
--- a/.changeset/lemon-eggs-learn.md
+++ b/.changeset/lemon-eggs-learn.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': minor
+---
+
+Fixed typescript rules linting unintended markdown snippets

--- a/packages/eslint-config/src/configs/typescript.ts
+++ b/packages/eslint-config/src/configs/typescript.ts
@@ -1,7 +1,7 @@
 import { renamePluginsInConfigs } from 'eslint-flat-config-utils';
 
 import { PluginNameMap } from '../constants';
-import { GLOB_SRC } from '../globs';
+import { GLOB_MARKDOWN_CODE, GLOB_SRC } from '../globs';
 import type { OptionsTypeScriptWithTypes, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
@@ -28,6 +28,7 @@ export async function typescript(options: OptionsTypeScriptWithTypes = {}): Prom
     {
       name: '2digits:typescript/rules',
       files: [GLOB_SRC],
+      ignores: [GLOB_MARKDOWN_CODE],
       languageOptions: {
         parser,
         parserOptions: {
@@ -66,14 +67,15 @@ export async function typescript(options: OptionsTypeScriptWithTypes = {}): Prom
         ],
         'ts/unbound-method': 'off',
 
-        ...(twoDigits.configs.recommended.rules as object),
+        ...twoDigits.configs.recommended.rules,
 
         ...overrides,
       },
     },
     {
-      files: ['**/*.d.ts'],
       name: '2digits:typescript/disables/dts',
+      files: ['**/*.d.ts'],
+      ignores: [GLOB_MARKDOWN_CODE],
       rules: {
         'unicorn/no-abusive-eslint-disable': 'off',
         'no-duplicate-imports': 'off',
@@ -82,15 +84,17 @@ export async function typescript(options: OptionsTypeScriptWithTypes = {}): Prom
       },
     },
     {
-      files: ['**/*.{test,spec}.ts?(x)'],
       name: '2digits:typescript/disables/test',
+      files: ['**/*.{test,spec}.ts?(x)'],
+      ignores: [GLOB_MARKDOWN_CODE],
       rules: {
         'no-unused-expressions': 'off',
       },
     },
     {
-      files: ['**/*.js', '**/*.cjs', '**/*.cts'],
       name: '2digits:typescript/disables/cjs',
+      files: ['**/*.js', '**/*.cjs', '**/*.cts'],
+      ignores: [GLOB_MARKDOWN_CODE],
       rules: {
         'ts/no-require-imports': 'off',
         'ts/no-var-requires': 'off',


### PR DESCRIPTION
# Fixed TypeScript rules linting unintended markdown snippets

This PR prevents TypeScript ESLint rules from being applied to code snippets within markdown files. The fix adds `ignores: [GLOB_MARKDOWN_CODE]` to all TypeScript-related rule configurations, ensuring that code examples in documentation aren't incorrectly flagged by TypeScript linting rules.

Additionally, the PR improves the organization of the configuration by consistently placing the `name` property before `files` and `ignores` in each config object for better readability.