### PR TITLE
⬆️ Update eslint-plugin-jsdoc to 50.6.9 and renovate to 39.211.2

### DIFF
--- a/.changeset/breezy-glasses-fold.md
+++ b/.changeset/breezy-glasses-fold.md
@@ -1,0 +1,6 @@
+---
+'@2digits/eslint-config': patch
+'@2digits/renovate-config': patch
+---
+
+Updated dependencies

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ catalogs:
       specifier: 0.2.3
       version: 0.2.3
     eslint-plugin-jsdoc:
-      specifier: 50.6.8
-      version: 50.6.8
+      specifier: 50.6.9
+      version: 50.6.9
     eslint-plugin-jsonc:
       specifier: 2.19.1
       version: 2.19.1
@@ -190,8 +190,8 @@ catalogs:
       specifier: 19.0.0
       version: 19.0.0
     renovate:
-      specifier: 39.211.0
-      version: 39.211.0
+      specifier: 39.211.2
+      version: 39.211.2
     tinyglobby:
       specifier: 0.2.12
       version: 0.2.12
@@ -359,7 +359,7 @@ importers:
         version: 0.2.3(eslint@9.23.0(jiti@2.4.2))
       eslint-plugin-jsdoc:
         specifier: 'catalog:'
-        version: 50.6.8(eslint@9.23.0(jiti@2.4.2))
+        version: 50.6.9(eslint@9.23.0(jiti@2.4.2))
       eslint-plugin-jsonc:
         specifier: 'catalog:'
         version: 2.19.1(eslint@9.23.0(jiti@2.4.2))
@@ -551,7 +551,7 @@ importers:
         version: 1.0.44
       renovate:
         specifier: 'catalog:'
-        version: 39.211.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 39.211.2(encoding@0.1.13)(typanion@3.14.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -2505,9 +2505,6 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.13.10':
-    resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
-
   '@types/node@22.13.11':
     resolution: {integrity: sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==}
 
@@ -3450,8 +3447,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-jsdoc@50.6.8:
-    resolution: {integrity: sha512-PPZVqhoXaalMQwDGzcQrJtPSPIPOYsSMtvkjYAdsIazOW20yhYtVX4+jLL+XznD4zYTXyZbPWPRKkNev4D4lyw==}
+  eslint-plugin-jsdoc@50.6.9:
+    resolution: {integrity: sha512-7/nHu3FWD4QRG8tCVqcv+BfFtctUtEDWc29oeDXB4bwmDM2/r1ndl14AG/2DUntdqH7qmpvdemJKwb3R97/QEw==}
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
@@ -4822,6 +4819,11 @@ packages:
   nan@2.22.0:
     resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
 
+  nanoid@3.3.10:
+    resolution: {integrity: sha512-vSJJTG+t/dIKAUhUDw/dLdZ9s//5OxcHqLaDWWrW4Cdq7o6tdLIczUkMXt2MBNmk6sJRZBZRXVixs7URY1CmIg==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@3.3.9:
     resolution: {integrity: sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -5513,8 +5515,8 @@ packages:
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
 
-  renovate@39.211.0:
-    resolution: {integrity: sha512-/m+9+Bceth+O6q5xOJ6H1BmYtSgbc3fdD9YEFrSpleezCeHIGs6UeMY79iABAHsTmSHB73T+4KJ9e6jJTfKcNg==}
+  renovate@39.211.2:
+    resolution: {integrity: sha512-chTBnCs2EPb3AGfpLTYxPDrPkhMaqz5AbqZ1DpeZXRwpBHfWB+Unu0uZX2VUoHAK/saxIgl25R7VHTSQTsnNOg==}
     engines: {node: ^20.15.1 || ^22.11.0, pnpm: ^10.0.0}
     hasBin: true
 
@@ -9467,13 +9469,13 @@ snapshots:
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.13.11
 
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 22.13.10
+      '@types/node': 22.13.11
       '@types/responselike': 1.0.3
 
   '@types/debug@4.1.12':
@@ -9495,7 +9497,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.13.11
 
   '@types/mdast@3.0.15':
     dependencies:
@@ -9513,10 +9515,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.13.10':
-    dependencies:
-      undici-types: 6.20.0
-
   '@types/node@22.13.11':
     dependencies:
       undici-types: 6.20.0
@@ -9531,7 +9529,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.13.11
 
   '@types/semver@7.5.8': {}
 
@@ -9551,7 +9549,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.13.11
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
@@ -10490,7 +10488,7 @@ snapshots:
       eslint: 9.23.0(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.23.0(jiti@2.4.2))
 
-  eslint-plugin-jsdoc@50.6.8(eslint@9.23.0(jiti@2.4.2)):
+  eslint-plugin-jsdoc@50.6.9(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       '@es-joy/jsdoccomment': 0.49.0
       are-docs-informative: 0.0.2
@@ -12289,6 +12287,8 @@ snapshots:
   nan@2.22.0:
     optional: true
 
+  nanoid@3.3.10: {}
+
   nanoid@3.3.9: {}
 
   napi-build-utils@1.0.2:
@@ -12770,7 +12770,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.13.10
+      '@types/node': 22.13.11
       long: 5.2.3
 
   protocols@2.0.1: {}
@@ -12974,7 +12974,7 @@ snapshots:
 
   remove-trailing-separator@1.1.0: {}
 
-  renovate@39.211.0(encoding@0.1.13)(typanion@3.14.0):
+  renovate@39.211.2(encoding@0.1.13)(typanion@3.14.0):
     dependencies:
       '@aws-sdk/client-codecommit': 3.738.0
       '@aws-sdk/client-ec2': 3.738.0
@@ -13057,7 +13057,7 @@ snapshots:
       minimatch: 10.0.1
       moo: 0.5.2
       ms: 2.1.3
-      nanoid: 3.3.9
+      nanoid: 3.3.10
       neotraverse: 0.6.18
       node-html-parser: 7.0.1
       p-all: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,7 +53,7 @@ catalog:
   eslint-plugin-antfu: 3.1.1
   eslint-plugin-de-morgan: 1.2.1
   eslint-plugin-drizzle: 0.2.3
-  eslint-plugin-jsdoc: 50.6.8
+  eslint-plugin-jsdoc: 50.6.9
   eslint-plugin-jsonc: 2.19.1
   eslint-plugin-n: 17.16.2
   eslint-plugin-pnpm: 0.3.1
@@ -86,7 +86,7 @@ catalog:
   prettier-plugin-tailwindcss: 0.6.11
   prettier-plugin-toml: 2.0.2
   react: 19.0.0
-  renovate: 39.211.0
+  renovate: 39.211.2
   tinyglobby: 0.2.12
   ts-pattern: 5.6.2
   tsup: 8.4.0


### PR DESCRIPTION
# Updated dependencies in @2digits/eslint-config and @2digits/renovate-config

This PR updates the following dependencies:

- Upgraded `eslint-plugin-jsdoc` from 50.6.8 to 50.6.9
- Upgraded `renovate` from 39.211.0 to 39.211.2

A changeset has been added to track these dependency updates for the next release.