### PR TITLE
⏱️ Increase timeout for eslint-config fixture tests

### DIFF
--- a/packages/eslint-config/test/fixtures.test.ts
+++ b/packages/eslint-config/test/fixtures.test.ts
@@ -14,7 +14,7 @@ afterAll(async () => {
   await fs.rm('_fixtures', { recursive: true, force: true });
 });
 
-it('should autofix', async ({ expect }) => {
+it('should autofix', { timeout: 30_000 }, async ({ expect }) => {
   const from = nodePath.resolve('fixtures/input');
   const output = nodePath.resolve('fixtures/output');
   const target = nodePath.resolve('_fixtures');


### PR DESCRIPTION
Increased timeout for autofix test to 30 seconds to prevent test failures in slower environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Extended the timeout for a test case to 30 seconds, ensuring more reliable execution and reducing premature failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->