### PR TITLE
🔧 Allow useless fragments for text content in eslint-config

### DIFF
--- a/.changeset/salty-colts-crash.md
+++ b/.changeset/salty-colts-crash.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Updated config to allow useless fragments for text content

--- a/packages/eslint-config/src/configs/react.ts
+++ b/packages/eslint-config/src/configs/react.ts
@@ -72,6 +72,7 @@ export async function react(
         'react-hooks-extra/no-redundant-custom-hook': 'error',
         'react-hooks-extra/no-unnecessary-use-memo': 'error',
 
+        'react-extra/no-useless-fragment': 'off',
         'react-extra/prefer-read-only-props': 'off',
         'react-extra/prefer-shorthand-boolean': 'error',
         'react-extra/prefer-shorthand-fragment': 'error',


### PR DESCRIPTION
Disabled the `react-extra/no-useless-fragment` ESLint rule to allow useless fragments for text content. This change enables developers to use React fragments even in cases where they might only contain text, which can be useful for certain component patterns and JSX structures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced linting configurations now allow extra fragment usage for text content, increasing flexibility in code styling.
	- Updated React settings disable warnings for unnecessary fragments, enabling broader use of fragment patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->