### PR TITLE
🔧 Enable pnpm in eslint config

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,4 +19,5 @@ export default twoDigits({
   turbo: true,
   drizzle: true,
   ts: true,
+  pnpm: true,
 });


### PR DESCRIPTION
Enabled PNPM linting rules by setting the `pnpm` flag to `true` in the ESLint configuration.