### PR TITLE
🔧 Import ESLint plugins directly instead of using plugins.ts

### DIFF
--- a/packages/eslint-config/src/configs/node.ts
+++ b/packages/eslint-config/src/configs/node.ts
@@ -1,5 +1,6 @@
+import pluginNode from 'eslint-plugin-n';
+
 import { GLOB_SRC } from '../globs';
-import { pluginNode } from '../plugins';
 import type { TypedFlatConfigItem } from '../types';
 
 export function node(): TypedFlatConfigItem[] {

--- a/packages/eslint-config/src/configs/sonar.ts
+++ b/packages/eslint-config/src/configs/sonar.ts
@@ -1,5 +1,6 @@
+import pluginSonar from 'eslint-plugin-sonarjs';
+
 import { GLOB_SRC } from '../globs';
-import { pluginSonar } from '../plugins';
 import type { TypedFlatConfigItem } from '../types';
 
 export function sonar(): TypedFlatConfigItem[] {

--- a/packages/eslint-config/src/configs/unicorn.ts
+++ b/packages/eslint-config/src/configs/unicorn.ts
@@ -1,5 +1,6 @@
+import pluginUnicorn from 'eslint-plugin-unicorn';
+
 import { GLOB_SRC } from '../globs';
-import { pluginUnicorn } from '../plugins';
 import type { TypedFlatConfigItem } from '../types';
 
 export function unicorn(): TypedFlatConfigItem[] {

--- a/packages/eslint-config/src/plugins.ts
+++ b/packages/eslint-config/src/plugins.ts
@@ -1,3 +1,0 @@
-export { default as pluginUnicorn } from 'eslint-plugin-unicorn';
-export { default as pluginNode } from 'eslint-plugin-n';
-export { default as pluginSonar } from 'eslint-plugin-sonarjs';


### PR DESCRIPTION
Refactored ESLint plugin imports by removing the centralized plugins.ts file and directly importing plugins in their respective config files. This change improves code organization by keeping plugin imports closer to where they're used in the node.ts, sonar.ts, and unicorn.ts configuration files.