### PR TITLE
🔧 Remove eslint-config-prettier declaration from stub.d.ts

### DIFF
--- a/.changeset/full-beans-behave.md
+++ b/.changeset/full-beans-behave.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Removed unused stub typings

--- a/packages/eslint-config/src/stub.d.ts
+++ b/packages/eslint-config/src/stub.d.ts
@@ -45,14 +45,6 @@ declare module 'eslint-plugin-tailwindcss' {
   export = exprt;
 }
 
-declare module 'eslint-config-prettier' {
-  import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
-
-  declare const exprt: ClassicConfig.Config;
-
-  export = exprt;
-}
-
 declare module 'eslint-plugin-react-compiler' {
   import type { ClassicConfig, Linter } from '@typescript-eslint/utils/ts-eslint';
 


### PR DESCRIPTION
Removed unnecessary type declaration for 'eslint-config-prettier' module in stub.d.ts