### PR TITLE
🔧 Optimize ESLint config imports for better performance

### DIFF
--- a/.changeset/fast-yaks-say.md
+++ b/.changeset/fast-yaks-say.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Deferred loading optional plugins

--- a/.changeset/seven-eggs-mate.md
+++ b/.changeset/seven-eggs-mate.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Loaded required plugins on start

--- a/packages/eslint-config/src/configs/graphql.ts
+++ b/packages/eslint-config/src/configs/graphql.ts
@@ -1,5 +1,4 @@
 import { renamePluginsInRules } from 'eslint-flat-config-utils';
-import { loadConfig } from 'graphql-config';
 
 import { PluginNameMap } from '../constants';
 import type { OptionsWithFiles, TypedFlatConfigItem } from '../types';
@@ -10,7 +9,9 @@ export async function graphql(options: OptionsWithFiles = {}): Promise<TypedFlat
 
   const [gql, gqlSchema] = await Promise.all([
     interopDefault(import('@graphql-eslint/eslint-plugin')),
-    loadConfig({ throwOnEmpty: false, throwOnMissing: false }).then((g) => g?.getDefault().schema),
+    import('graphql-config').then(({ loadConfig }) =>
+      loadConfig({ throwOnEmpty: false, throwOnMissing: false }).then((g) => g?.getDefault().schema),
+    ),
   ]);
 
   const flatRecommended = gql.configs['flat/operations-recommended'].rules;

--- a/packages/eslint-config/src/configs/ignores.ts
+++ b/packages/eslint-config/src/configs/ignores.ts
@@ -1,19 +1,16 @@
-import { composer } from 'eslint-flat-config-utils';
+import flatIgnore from 'eslint-config-flat-gitignore';
 
 import { GLOB_EXCLUDE } from '../globs';
 import type { OptionsWithIgnores, TypedFlatConfigItem } from '../types';
-import { interopDefault } from '../utils';
 
-export async function ignores(options: OptionsWithIgnores = {}): Promise<TypedFlatConfigItem[]> {
+export function ignores(options: OptionsWithIgnores = {}): TypedFlatConfigItem[] {
   const { gitIgnore, ignores = [] } = options;
 
-  return composer(
+  return [
     {
       ignores: [GLOB_EXCLUDE, ignores].flat(),
       name: '2digits:ignores',
     },
-    interopDefault(import('eslint-config-flat-gitignore')).then((m) =>
-      m({ strict: false, ...gitIgnore, name: '2digits:gitignore' }),
-    ),
-  );
+    flatIgnore({ strict: false, ...gitIgnore, name: '2digits:gitignore' }),
+  ];
 }

--- a/packages/eslint-config/src/configs/jsdoc.ts
+++ b/packages/eslint-config/src/configs/jsdoc.ts
@@ -1,14 +1,15 @@
+import jsdocPlugin from 'eslint-plugin-jsdoc';
+
 import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
-import { interopDefault } from '../utils';
 
-export async function jsdoc(): Promise<TypedFlatConfigItem[]> {
+export function jsdoc(): TypedFlatConfigItem[] {
   return [
     {
       files: [GLOB_SRC],
       name: '2digits:jsdoc',
       plugins: {
-        jsdoc: await interopDefault(import('eslint-plugin-jsdoc')),
+        jsdoc: jsdocPlugin,
       },
       rules: {
         'jsdoc/check-access': 'error',

--- a/packages/eslint-config/src/configs/pnpm.ts
+++ b/packages/eslint-config/src/configs/pnpm.ts
@@ -1,21 +1,18 @@
-import jsoncParser from 'jsonc-eslint-parser';
-import yamlParser from 'yaml-eslint-parser';
-
 import type { TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
 export async function pnpm(): Promise<TypedFlatConfigItem[]> {
-  const plugin = await interopDefault(import('eslint-plugin-pnpm'));
+  const pnpm = await interopDefault(import('eslint-plugin-pnpm'));
 
   return [
     {
       name: '2digits:pnpm/package-json',
       files: ['**/package.json'],
       languageOptions: {
-        parser: jsoncParser,
+        parser: await interopDefault(import('jsonc-eslint-parser')),
       },
       plugins: {
-        pnpm: plugin,
+        pnpm,
       },
       rules: {
         'pnpm/json-enforce-catalog': 'error',
@@ -27,10 +24,10 @@ export async function pnpm(): Promise<TypedFlatConfigItem[]> {
       name: '2digits:pnpm/pnpm-workspace-yaml',
       files: ['pnpm-workspace.yaml'],
       languageOptions: {
-        parser: yamlParser,
+        parser: await interopDefault(import('yaml-eslint-parser')),
       },
       plugins: {
-        pnpm: plugin,
+        pnpm,
       },
       rules: {
         'pnpm/yaml-no-duplicate-catalog-item': 'error',

--- a/packages/eslint-config/src/configs/react.ts
+++ b/packages/eslint-config/src/configs/react.ts
@@ -1,4 +1,3 @@
-import stylistic from '@stylistic/eslint-plugin';
 import { renamePluginsInRules } from 'eslint-flat-config-utils';
 
 import { PluginNameMap } from '../constants';
@@ -11,11 +10,12 @@ export async function react(
 ): Promise<TypedFlatConfigItem[]> {
   const { files = [GLOB_TS, GLOB_TSX], overrides = {}, parserOptions, tsconfigRootDir, reactCompiler = true } = options;
 
-  const [pluginReact, pluginReactHooks, parser, pluginReactCompiler] = await Promise.all([
+  const [pluginReact, pluginReactHooks, parser, pluginReactCompiler, stylistic] = await Promise.all([
     interopDefault(import('@eslint-react/eslint-plugin')),
     interopDefault(import('eslint-plugin-react-hooks')),
     interopDefault(import('@typescript-eslint/parser')),
     reactCompiler ? interopDefault(import('eslint-plugin-react-compiler')) : undefined,
+    interopDefault(import('@stylistic/eslint-plugin')),
   ]);
 
   const plugins = pluginReact.configs.all.plugins;


### PR DESCRIPTION
# Optimize ESLint Config Package for Dynamic Imports

This PR improves the ESLint configuration package by optimizing how dependencies are imported:

1. Refactored `graphql.ts` to use dynamic import for `loadConfig` from `graphql-config` only when needed
2. Changed `ignores.ts` to use direct imports instead of async functions, removing unnecessary `composer` usage
3. Converted `jsdoc.ts` to use synchronous imports and function
4. Improved `pnpm.ts` by dynamically importing parsers only when needed
5. Fixed `react.ts` by moving `stylistic` import into the Promise.all to maintain consistency

These changes reduce unnecessary async operations and improve the loading pattern of dependencies throughout the configuration files.