### PR TITLE
🔧 Simplify exports in eslint-config package

### DIFF
--- a/.changeset/old-chefs-ring.md
+++ b/.changeset/old-chefs-ring.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Removed unused exports from index.ts

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -1,5 +1,3 @@
-export * from './configs';
 export type * from './types';
-export * from './factory';
 
-export { twoDigits as default } from './factory';
+export { twoDigits as default, twoDigits } from './factory';


### PR DESCRIPTION
Simplified exports from eslint-config package by removing the configs export and only exporting the twoDigits function (both as default and named export). Type exports are maintained.