### PR TITLE
🚀 Improve performance by moving function creation out of hot path

### DIFF
--- a/.changeset/smooth-mails-count.md
+++ b/.changeset/smooth-mails-count.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-plugin': minor
+---
+
+Improved performance by moving function creation out of hot path

--- a/packages/eslint-plugin/src/rules/type-param-names.ts
+++ b/packages/eslint-plugin/src/rules/type-param-names.ts
@@ -51,12 +51,7 @@ export const typeParamNames = createEslintRule<[], MessageId>({
         for (const param of params) {
           const { name } = param.name;
 
-          const messageId = match(name)
-            .with(P.string.regex(TypeParamRegex), () => false as const)
-            .with(P.not(P.string.regex(PrefixRegex)), () => MessageId.prefix)
-            .with(P.not(P.string.regex(InitialRegex)), () => MessageId.initial)
-            .with(P.not(P.string.regex(RemainderRegex)), () => MessageId.remainder)
-            .otherwise(() => false as const);
+          const messageId = getMessageId(name);
 
           if (messageId) {
             context.report({
@@ -70,3 +65,17 @@ export const typeParamNames = createEslintRule<[], MessageId>({
     };
   },
 });
+
+const typeParamSelect = P.string.regex(TypeParamRegex);
+const prefixSelect = P.not(P.string.regex(PrefixRegex));
+const initialSelect = P.not(P.string.regex(InitialRegex));
+const remainderSelect = P.not(P.string.regex(RemainderRegex));
+
+function getMessageId(name: string) {
+  return match(name)
+    .with(typeParamSelect, () => false as const)
+    .with(prefixSelect, () => MessageId.prefix)
+    .with(initialSelect, () => MessageId.initial)
+    .with(remainderSelect, () => MessageId.remainder)
+    .otherwise(() => false as const);
+}


### PR DESCRIPTION
# Performance Improvement in Type Parameter Name Validation

This PR improves the performance of the `type-param-names` rule by moving the pattern matching function creation out of the hot path. Instead of creating new pattern matchers on each iteration, we now:

1. Define the pattern selectors once outside the loop
2. Extract the matching logic into a separate `getMessageId` function
3. Reuse these patterns for all type parameter validations

This change reduces unnecessary object creation during rule execution, resulting in better performance when processing files with many type parameters.