### PR TITLE
🔧 Precompile magic-regexps during build for eslint-plugin

### DIFF
--- a/.changeset/cute-ducks-greet.md
+++ b/.changeset/cute-ducks-greet.md
@@ -2,4 +2,4 @@
 '@2digits/eslint-plugin': minor
 ---
 
-Precompiled magix-regexps during build
+Precompiled magic-regexps during build

--- a/.changeset/cute-ducks-greet.md
+++ b/.changeset/cute-ducks-greet.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-plugin': minor
+---
+
+Precompiled magix-regexps during build

--- a/packages/eslint-plugin/build.config.ts
+++ b/packages/eslint-plugin/build.config.ts
@@ -1,7 +1,18 @@
+import { MagicRegExpTransformPlugin } from 'magic-regexp/transform';
 import { defineBuildConfig } from 'unbuild';
 
 export default defineBuildConfig({
   entries: ['./src/index.ts'],
 
   declaration: true,
+
+  rollup: {
+    inlineDependencies: ['magic-regexp'],
+  },
+
+  hooks: {
+    'rollup:options': (_ctx, config) => {
+      config.plugins.push(MagicRegExpTransformPlugin.rollup());
+    },
+  },
 });

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -37,13 +37,13 @@
   "dependencies": {
     "@typescript-eslint/utils": "catalog:",
     "eslint": "catalog:",
-    "magic-regexp": "catalog:",
     "ts-pattern": "catalog:"
   },
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
     "@typescript-eslint/parser": "catalog:",
     "eslint-vitest-rule-tester": "catalog:",
+    "magic-regexp": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"

--- a/packages/eslint-plugin/src/rules/type-param-names.ts
+++ b/packages/eslint-plugin/src/rules/type-param-names.ts
@@ -3,15 +3,15 @@ import { match, P } from 'ts-pattern';
 
 import { createEslintRule } from '../utils';
 
-const prefix = anyOf('T', '$').at.lineStart();
-const initial = letter.uppercase;
-const remainder = oneOrMore(letter);
-const digits = digit.times.any().at.lineEnd();
-
-const PrefixRegex = createRegExp(prefix);
-const InitialRegex = createRegExp(prefix, initial);
-const RemainderRegex = createRegExp(prefix, initial, remainder);
-const TypeParamRegex = createRegExp(prefix, initial, remainder, digits);
+const PrefixRegex = createRegExp(anyOf('T', '$').at.lineStart());
+const InitialRegex = createRegExp(anyOf('T', '$').at.lineStart(), letter.uppercase);
+const RemainderRegex = createRegExp(anyOf('T', '$').at.lineStart(), letter.uppercase, oneOrMore(letter));
+const TypeParamRegex = createRegExp(
+  anyOf('T', '$').at.lineStart(),
+  letter.uppercase,
+  oneOrMore(letter),
+  digit.times.any().at.lineEnd(),
+);
 
 type MessageId = (typeof MessageId)[keyof typeof MessageId];
 const MessageId = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,9 +472,6 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.24.0(jiti@2.4.2)
-      magic-regexp:
-        specifier: 'catalog:'
-        version: 0.8.0
       ts-pattern:
         specifier: 'catalog:'
         version: 5.7.0
@@ -488,6 +485,9 @@ importers:
       eslint-vitest-rule-tester:
         specifier: 'catalog:'
         version: 2.2.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.14.0))
+      magic-regexp:
+        specifier: 'catalog:'
+        version: 0.8.0
       typescript:
         specifier: 'catalog:'
         version: 5.8.3


### PR DESCRIPTION
# Precompile magic-regexps during build

This PR optimizes the `@2digits/eslint-plugin` package by precompiling magic-regexps during the build process. The changes include:

- Added the `MagicRegExpTransformPlugin` to the build configuration
- Configured rollup to inline the `magic-regexp` dependency
- Moved `magic-regexp` from dependencies to devDependencies
- Refactored regex definitions in `type-param-names.ts` to improve readability

These changes should improve runtime performance by ensuring all magic-regexps are compiled at build time rather than at runtime.