### PR TITLE
🔧 Fix ESM CJS interop in prettier-config by disabling cjsBridge

### DIFF
--- a/.changeset/smart-candles-rest.md
+++ b/.changeset/smart-candles-rest.md
@@ -1,0 +1,5 @@
+---
+'@2digits/prettier-config': minor
+---
+
+Fixed ESM CJS interop in unbuild

--- a/packages/prettier-config/build.config.ts
+++ b/packages/prettier-config/build.config.ts
@@ -7,6 +7,6 @@ export default defineBuildConfig({
 
   rollup: {
     emitCJS: true,
-    cjsBridge: false,
+    cjsBridge: true,
   },
 });

--- a/packages/prettier-config/build.config.ts
+++ b/packages/prettier-config/build.config.ts
@@ -7,5 +7,6 @@ export default defineBuildConfig({
 
   rollup: {
     emitCJS: true,
+    cjsBridge: false,
   },
 });


### PR DESCRIPTION
Fixed ESM CJS interop in unbuild for `@2digits/prettier-config` by disabling the CJS bridge in the rollup configuration. This change ensures proper interoperability between ESM and CommonJS modules while still emitting CJS output.