### PR TITLE
🔄 Update TypeScript array syntax to use generic type and fix linting issues

### DIFF
--- a/.changeset/angry-ducks-play.md
+++ b/.changeset/angry-ducks-play.md
@@ -1,0 +1,6 @@
+---
+'@2digits/eslint-config': patch
+'@2digits/eslint-plugin': patch
+---
+
+Updated code to match linting rules

--- a/.changeset/thick-animals-begin.md
+++ b/.changeset/thick-animals-begin.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': minor
+---
+
+Updated ts/array-type to the `generic` option

--- a/packages/eslint-config/build.config.ts
+++ b/packages/eslint-config/build.config.ts
@@ -41,9 +41,9 @@ async function generateTypes() {
     ...(Object.values(await import('./src/configs')).map((config) => config()) as []),
   );
 
-  const configNames = configs.map((i) => i.name).filter(Boolean) as string[];
+  const configNames = configs.map((i) => i.name).filter(Boolean) as Array<string>;
 
-  let dts = await flatConfigsToRulesDTS(configs as Linter.Config[], {
+  let dts = await flatConfigsToRulesDTS(configs as Array<Linter.Config>, {
     includeAugmentation: false,
   });
 

--- a/packages/eslint-config/src/configs/antfu.ts
+++ b/packages/eslint-config/src/configs/antfu.ts
@@ -3,7 +3,7 @@ import pluginAntfu from 'eslint-plugin-antfu';
 import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function antfu(): TypedFlatConfigItem[] {
+export function antfu(): Array<TypedFlatConfigItem> {
   return [
     {
       files: [GLOB_SRC],

--- a/packages/eslint-config/src/configs/boolean.ts
+++ b/packages/eslint-config/src/configs/boolean.ts
@@ -3,7 +3,7 @@ import pluginDeMorgan from 'eslint-plugin-de-morgan';
 import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function boolean(): TypedFlatConfigItem[] {
+export function boolean(): Array<TypedFlatConfigItem> {
   return [
     {
       files: [GLOB_SRC],

--- a/packages/eslint-config/src/configs/comments.ts
+++ b/packages/eslint-config/src/configs/comments.ts
@@ -8,7 +8,7 @@ import type { TypedFlatConfigItem } from '../types';
 
 const recommended = renamePluginsInRules(configs.recommended.rules as never, PluginNameMap);
 
-export function comments(): TypedFlatConfigItem[] {
+export function comments(): Array<TypedFlatConfigItem> {
   return [
     {
       files: [GLOB_SRC],

--- a/packages/eslint-config/src/configs/css.ts
+++ b/packages/eslint-config/src/configs/css.ts
@@ -4,7 +4,7 @@ import { tailwindSyntax } from '@eslint/css/syntax';
 import { GLOB_CSS } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function css(): TypedFlatConfigItem[] {
+export function css(): Array<TypedFlatConfigItem> {
   return [
     {
       name: '2digits:css',

--- a/packages/eslint-config/src/configs/drizzle.ts
+++ b/packages/eslint-config/src/configs/drizzle.ts
@@ -4,7 +4,7 @@ import { GLOB_SRC } from '../globs';
 import type { OptionsWithDrizzle, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
-export async function drizzle(options: OptionsWithDrizzle = {}): Promise<TypedFlatConfigItem[]> {
+export async function drizzle(options: OptionsWithDrizzle = {}): Promise<Array<TypedFlatConfigItem>> {
   const { overrides = {}, drizzleObjectName = ['drizzle', 'db'] } = options;
 
   const drizzle = await interopDefault(import('eslint-plugin-drizzle'));

--- a/packages/eslint-config/src/configs/graphql.ts
+++ b/packages/eslint-config/src/configs/graphql.ts
@@ -4,7 +4,7 @@ import { PluginNameMap } from '../constants';
 import type { OptionsWithFiles, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
-export async function graphql(options: OptionsWithFiles = {}): Promise<TypedFlatConfigItem[]> {
+export async function graphql(options: OptionsWithFiles = {}): Promise<Array<TypedFlatConfigItem>> {
   const { overrides = {}, files = ['**/*.graphql', '**/*.gql'] } = options;
 
   const [gql, gqlSchema] = await Promise.all([

--- a/packages/eslint-config/src/configs/ignores.ts
+++ b/packages/eslint-config/src/configs/ignores.ts
@@ -3,7 +3,7 @@ import flatIgnore from 'eslint-config-flat-gitignore';
 import { GLOB_EXCLUDE } from '../globs';
 import type { OptionsWithIgnores, TypedFlatConfigItem } from '../types';
 
-export function ignores(options: OptionsWithIgnores = {}): TypedFlatConfigItem[] {
+export function ignores(options: OptionsWithIgnores = {}): Array<TypedFlatConfigItem> {
   const { gitIgnore, ignores = [] } = options;
 
   return [

--- a/packages/eslint-config/src/configs/javascript.ts
+++ b/packages/eslint-config/src/configs/javascript.ts
@@ -5,7 +5,7 @@ import globals from 'globals';
 import { GLOB_SRC } from '../globs';
 import type { OptionsOverrides, TypedFlatConfigItem } from '../types';
 
-export function javascript(options: OptionsOverrides = {}): TypedFlatConfigItem[] {
+export function javascript(options: OptionsOverrides = {}): Array<TypedFlatConfigItem> {
   const { overrides = {} } = options;
 
   return [

--- a/packages/eslint-config/src/configs/jsdoc.ts
+++ b/packages/eslint-config/src/configs/jsdoc.ts
@@ -3,7 +3,7 @@ import jsdocPlugin from 'eslint-plugin-jsdoc';
 import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function jsdoc(): TypedFlatConfigItem[] {
+export function jsdoc(): Array<TypedFlatConfigItem> {
   return [
     {
       files: [GLOB_SRC],

--- a/packages/eslint-config/src/configs/jsonc.ts
+++ b/packages/eslint-config/src/configs/jsonc.ts
@@ -4,7 +4,7 @@ import parser from 'jsonc-eslint-parser';
 import { GLOB_JSON, GLOB_JSON5, GLOB_JSONC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function jsonc(): TypedFlatConfigItem[] {
+export function jsonc(): Array<TypedFlatConfigItem> {
   return [
     ...configs['flat/base'].map((config) => ({ ...config, name: '2digits:jsonc/base' })),
 

--- a/packages/eslint-config/src/configs/markdown.ts
+++ b/packages/eslint-config/src/configs/markdown.ts
@@ -6,7 +6,7 @@ import type { TypedFlatConfigItem } from '../types';
 
 const files = [GLOB_MARKDOWN];
 
-export function markdown(): TypedFlatConfigItem[] {
+export function markdown(): Array<TypedFlatConfigItem> {
   return [
     {
       name: '2digits:markdown/setup',

--- a/packages/eslint-config/src/configs/next.ts
+++ b/packages/eslint-config/src/configs/next.ts
@@ -8,7 +8,7 @@ import { interopDefault } from '../utils';
 
 export async function next(
   options: OptionsWithFiles & OptionsTypeScriptWithTypes = {},
-): Promise<TypedFlatConfigItem[]> {
+): Promise<Array<TypedFlatConfigItem>> {
   const { files = [GLOB_TS, GLOB_TSX], overrides = {}, parserOptions } = options;
 
   const [next, parser] = await Promise.all([

--- a/packages/eslint-config/src/configs/node.ts
+++ b/packages/eslint-config/src/configs/node.ts
@@ -3,7 +3,7 @@ import pluginNode from 'eslint-plugin-n';
 import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function node(): TypedFlatConfigItem[] {
+export function node(): Array<TypedFlatConfigItem> {
   return [
     {
       files: [GLOB_SRC],

--- a/packages/eslint-config/src/configs/pnpm.ts
+++ b/packages/eslint-config/src/configs/pnpm.ts
@@ -1,7 +1,7 @@
 import type { TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
-export async function pnpm(): Promise<TypedFlatConfigItem[]> {
+export async function pnpm(): Promise<Array<TypedFlatConfigItem>> {
   const pnpm = await interopDefault(import('eslint-plugin-pnpm'));
 
   return [

--- a/packages/eslint-config/src/configs/prettier.ts
+++ b/packages/eslint-config/src/configs/prettier.ts
@@ -1,7 +1,7 @@
 import type { TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
-export async function prettier(): Promise<TypedFlatConfigItem[]> {
+export async function prettier(): Promise<Array<TypedFlatConfigItem>> {
   const [prettier, stylistic] = await Promise.all([
     interopDefault(import('eslint-config-prettier')),
     interopDefault(import('@stylistic/eslint-plugin')),

--- a/packages/eslint-config/src/configs/react.ts
+++ b/packages/eslint-config/src/configs/react.ts
@@ -7,7 +7,7 @@ import { interopDefault } from '../utils';
 
 export async function react(
   options: OptionsWithReact & OptionsTypeScriptWithTypes = {},
-): Promise<TypedFlatConfigItem[]> {
+): Promise<Array<TypedFlatConfigItem>> {
   const { files = [GLOB_TS, GLOB_TSX], overrides = {}, parserOptions, tsconfigRootDir, reactCompiler = true } = options;
 
   const [pluginReact, pluginReactHooks, parser, pluginReactCompiler, stylistic] = await Promise.all([

--- a/packages/eslint-config/src/configs/regexp.ts
+++ b/packages/eslint-config/src/configs/regexp.ts
@@ -3,7 +3,7 @@ import pluginRegexp from 'eslint-plugin-regexp';
 import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function regexp(): TypedFlatConfigItem[] {
+export function regexp(): Array<TypedFlatConfigItem> {
   return [
     {
       files: [GLOB_SRC],

--- a/packages/eslint-config/src/configs/sonar.ts
+++ b/packages/eslint-config/src/configs/sonar.ts
@@ -3,7 +3,7 @@ import pluginSonar from 'eslint-plugin-sonarjs';
 import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function sonar(): TypedFlatConfigItem[] {
+export function sonar(): Array<TypedFlatConfigItem> {
   return [
     {
       files: [GLOB_SRC],

--- a/packages/eslint-config/src/configs/storybook.ts
+++ b/packages/eslint-config/src/configs/storybook.ts
@@ -7,7 +7,7 @@ import { interopDefault } from '../utils';
 
 export async function storybook(
   options: OptionsWithStorybook & OptionsTypeScriptWithTypes = {},
-): Promise<TypedFlatConfigItem[]> {
+): Promise<Array<TypedFlatConfigItem>> {
   const { files = [GLOB_STORIES], overrides = {}, parserOptions, storybookDirectory = '.storybook' } = options;
 
   const [storybook, parser] = await Promise.all([

--- a/packages/eslint-config/src/configs/tailwind.ts
+++ b/packages/eslint-config/src/configs/tailwind.ts
@@ -4,7 +4,7 @@ import { GLOB_SRC } from '../globs';
 import type { OptionsOverrides, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
-export async function tailwind(options: OptionsOverrides = {}): Promise<TypedFlatConfigItem[]> {
+export async function tailwind(options: OptionsOverrides = {}): Promise<Array<TypedFlatConfigItem>> {
   const { overrides = {} } = options;
 
   const [tailwindcss, { tailwindFunctions }, config] = await Promise.all([

--- a/packages/eslint-config/src/configs/tanstack.ts
+++ b/packages/eslint-config/src/configs/tanstack.ts
@@ -5,7 +5,7 @@ import { GLOB_SRC } from '../globs';
 import type { OptionsOverrides, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
-export async function tanstack(options: OptionsOverrides = {}): Promise<TypedFlatConfigItem[]> {
+export async function tanstack(options: OptionsOverrides = {}): Promise<Array<TypedFlatConfigItem>> {
   const { overrides = {} } = options;
 
   const tanstack = await interopDefault(import('@tanstack/eslint-plugin-query'));

--- a/packages/eslint-config/src/configs/turbo.ts
+++ b/packages/eslint-config/src/configs/turbo.ts
@@ -2,7 +2,7 @@ import { GLOB_SRC } from '../globs';
 import type { OptionsOverrides, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
-export async function turbo(options: OptionsOverrides = {}): Promise<TypedFlatConfigItem[]> {
+export async function turbo(options: OptionsOverrides = {}): Promise<Array<TypedFlatConfigItem>> {
   const { overrides = {} } = options;
 
   const turbo = await interopDefault(import('eslint-plugin-turbo'));

--- a/packages/eslint-config/src/configs/typescript.ts
+++ b/packages/eslint-config/src/configs/typescript.ts
@@ -5,7 +5,7 @@ import { GLOB_MARKDOWN_CODE, GLOB_SRC } from '../globs';
 import type { OptionsTypeScriptWithTypes, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
-export async function typescript(options: OptionsTypeScriptWithTypes = {}): Promise<TypedFlatConfigItem[]> {
+export async function typescript(options: OptionsTypeScriptWithTypes = {}): Promise<Array<TypedFlatConfigItem>> {
   const { overrides = {}, parserOptions = {} } = options;
 
   const [{ plugin, configs, parser }, twoDigits] = await Promise.all([

--- a/packages/eslint-config/src/configs/typescript.ts
+++ b/packages/eslint-config/src/configs/typescript.ts
@@ -41,6 +41,7 @@ export async function typescript(options: OptionsTypeScriptWithTypes = {}): Prom
       },
       rules: {
         ...rules,
+        'ts/array-type': ['error', { default: 'generic', readonly: 'generic' }],
         'ts/restrict-template-expressions': ['error', { allowNumber: true }],
         'ts/ban-ts-comment': ['error', { 'ts-ignore': 'allow-with-description' }],
         'ts/consistent-type-exports': ['error'],

--- a/packages/eslint-config/src/configs/unicorn.ts
+++ b/packages/eslint-config/src/configs/unicorn.ts
@@ -3,7 +3,7 @@ import pluginUnicorn from 'eslint-plugin-unicorn';
 import { GLOB_SRC } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function unicorn(): TypedFlatConfigItem[] {
+export function unicorn(): Array<TypedFlatConfigItem> {
   return [
     {
       files: [GLOB_SRC],

--- a/packages/eslint-config/src/configs/yaml.ts
+++ b/packages/eslint-config/src/configs/yaml.ts
@@ -4,7 +4,7 @@ import parser from 'yaml-eslint-parser';
 import { GLOB_YAML } from '../globs';
 import type { TypedFlatConfigItem } from '../types';
 
-export function yaml(): TypedFlatConfigItem[] {
+export function yaml(): Array<TypedFlatConfigItem> {
   return [
     {
       name: '2digits:yaml/setup',

--- a/packages/eslint-config/src/factory.ts
+++ b/packages/eslint-config/src/factory.ts
@@ -81,8 +81,8 @@ function config<T>(options: SharedOptions<T> | undefined | boolean): T {
 
 export async function twoDigits(
   options: ESLint2DigitsOptions = {},
-  ...userConfig: TypedFlatConfigItem[]
-): Promise<TypedFlatConfigItem[]> {
+  ...userConfig: Array<TypedFlatConfigItem>
+): Promise<Array<TypedFlatConfigItem>> {
   let pnpmPromise;
 
   if (options.pnpm === undefined) {

--- a/packages/eslint-config/src/types.ts
+++ b/packages/eslint-config/src/types.ts
@@ -34,7 +34,7 @@ export interface OptionsWithDrizzle extends OptionsOverrides {
    *
    * @default ```['drizzle', 'db']```
    */
-  drizzleObjectName?: string | string[];
+  drizzleObjectName?: string | Array<string>;
 }
 
 export interface OptionsTypeScriptWithTypes extends OptionsOverrides {
@@ -51,7 +51,7 @@ export interface OptionsTypeScriptWithTypes extends OptionsOverrides {
 
 export interface OptionsWithFiles extends OptionsOverrides {
   /** An array of glob patterns to match the files to which this configuration applies. */
-  files?: string[];
+  files?: Array<string>;
 }
 
 export interface OptionsWithStorybook extends OptionsWithFiles {
@@ -77,5 +77,5 @@ export interface OptionsWithIgnores {
   gitIgnore?: Omit<FlatGitignoreOptions, 'name' | 'root'>;
 
   /** An array of glob patterns to ignore in addition to the default ignores. */
-  ignores?: string[];
+  ignores?: Array<string>;
 }

--- a/packages/eslint-plugin/src/utils/index.ts
+++ b/packages/eslint-plugin/src/utils/index.ts
@@ -7,7 +7,7 @@ import { repository } from '../../package.json';
 const blobUrl = `${repository.url.replaceAll('.git', '')}/tree/main/${repository.directory}/src/rules`;
 
 /** @public */
-export interface RuleModule<T extends readonly unknown[]> extends Rule.RuleModule {
+export interface RuleModule<T extends ReadonlyArray<unknown>> extends Rule.RuleModule {
   defaultOptions: T;
 }
 
@@ -20,7 +20,7 @@ export interface RuleModule<T extends readonly unknown[]> extends Rule.RuleModul
 function RuleCreator(urlCreator: (name: string) => string) {
   // This function will get much easier to call when this is merged https://github.com/Microsoft/TypeScript/pull/26349
   // TODO - when the above PR lands; add type checking for the context.report `data` property
-  return function createNamedRule<TOptions extends readonly Record<string, unknown>[], TMessageIds extends string>({
+  return function createNamedRule<TOptions extends ReadonlyArray<Record<string, unknown>>, TMessageIds extends string>({
     name,
     meta,
     ...rule
@@ -38,7 +38,7 @@ function RuleCreator(urlCreator: (name: string) => string) {
   };
 }
 
-function createRule<TOptions extends readonly Record<string, unknown>[], TMessageIds extends string>({
+function createRule<TOptions extends ReadonlyArray<Record<string, unknown>>, TMessageIds extends string>({
   create,
   defaultOptions,
   meta,
@@ -60,7 +60,7 @@ function createRule<TOptions extends readonly Record<string, unknown>[], TMessag
 }
 
 export const createEslintRule = RuleCreator((ruleName) => `${blobUrl}${ruleName}.ts`) as unknown as <
-  TOptions extends readonly unknown[],
+  TOptions extends ReadonlyArray<unknown>,
   TMessageIds extends string,
 >({
   name,

--- a/packages/eslint-plugin/tests/rules/type-param-names.test.ts
+++ b/packages/eslint-plugin/tests/rules/type-param-names.test.ts
@@ -6,7 +6,7 @@ import { RULE_NAME, typeParamNames } from '../../src/rules/type-param-names';
 /** Gives nice syntax highlighting */
 const typescript = String.raw;
 
-const valids: ValidTestCase[] = [
+const valids: Array<ValidTestCase> = [
   typescript`type Foo<T> = T;`,
 
   typescript`
@@ -24,7 +24,7 @@ const valids: ValidTestCase[] = [
   typescript`type Foo<$Data, $Error> = $Data | $Error;`,
 ];
 
-const invalids: InvalidTestCase[] = [
+const invalids: Array<InvalidTestCase> = [
   {
     code: typescript` type Foo<U> = U; `,
     errors: [{ messageId: 'prefix', data: { name: 'U' } }],


### PR DESCRIPTION
# Update TypeScript array type to use 'generic' option

This PR updates the TypeScript array type rule to use the 'generic' option, which enforces the use of `Array<T>` syntax instead of `T[]`.

The changes include:
- Updated the TypeScript configuration to set `ts/array-type` rule to use the 'generic' option
- Converted all array type annotations in the codebase from `T[]` to `Array<T>` syntax
- Added changesets for the affected packages:
  - Minor version bump for `@2digits/eslint-config` for the rule change
  - Patch version bump for both packages to align with the new linting rules

This change provides more consistency in type declarations throughout the codebase.