### PR TITLE
🔄 Update eslint config path in turbo.json inputs

### DIFF
--- a/packages/eslint-config/turbo.json
+++ b/packages/eslint-config/turbo.json
@@ -4,7 +4,7 @@
     "docs": {
       "outputs": ["./.eslint-config-inspector/**"],
       "dependsOn": ["build", "^build"],
-      "inputs": ["$TURBO_DEFAULT$", "../../eslint.config.js"]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/eslint.config.ts"]
     },
     "docs:dev": {
       "dependsOn": ["build", "^build"],


### PR DESCRIPTION
Updated the `docs` task in `packages/eslint-config/turbo.json` to reference the TypeScript version of the ESLint config file. Changed the input path from `../../eslint.config.js` to `$TURBO_ROOT$/eslint.config.ts`, using the Turborepo root variable for better path resolution.