### PR TITLE
🔄 Remove renovate package entry from knip config

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -1,9 +1,6 @@
 {
   "$schema": "./node_modules/knip/schema.json",
   "workspaces": {
-    "packages/renovate": {
-      "entry": ["build.ts"]
-    },
     "packages/eslint-config": {
       "ignore": ["fixtures/**", "_fixtures/**"],
       "ignoreDependencies": ["react", "@types/react"]


### PR DESCRIPTION
Removed `packages/renovate` workspace configuration from `.knip.json` while preserving the `packages/eslint-config` workspace settings.