### PR TITLE
🔄 Mark pnpm-lock.yaml as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pnpm-lock.yaml linguist-generated=true


### PR DESCRIPTION
Added `.gitattributes` file to mark `pnpm-lock.yaml` as a generated file, which will exclude it from language statistics in GitHub.