### PR TITLE
🔧 Enable package manager version management and add ENABLE_EXPERIMENTAL_COREPACK env var

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,7 +75,7 @@ catalog:
 
 catalogMode: strict
 
-managePackageManagerVersions: false
+managePackageManagerVersions: true
 
 onlyBuiltDependencies:
   - esbuild

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "globalPassThroughEnv": ["FORCE_COLOR", "COREPACK_HOME"],
+  "globalPassThroughEnv": ["FORCE_COLOR", "COREPACK_HOME", "ENABLE_EXPERIMENTAL_COREPACK"],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
# Enable package manager version management and add experimental Corepack environment variable

This PR makes two changes:

1. Enables package manager version management by setting `managePackageManagerVersions: true` in `pnpm-workspace.yaml`
2. Adds `ENABLE_EXPERIMENTAL_COREPACK` to the list of environment variables passed through in `turbo.json`

These changes will help ensure consistent package manager versions across the project and allow for experimental Corepack features to be enabled when needed.