### PR TITLE
🔄 Update pnpm to 10.12.3 and dependencies across packages

### DIFF
--- a/.changeset/twelve-views-refuse.md
+++ b/.changeset/twelve-views-refuse.md
@@ -1,0 +1,7 @@
+---
+'@2digits/prettier-config': patch
+'@2digits/eslint-config': patch
+'@2digits/renovate-config': patch
+---
+
+Updated dependencies

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
   node = "22.16.0"
-  pnpm = "10.12.2"
+  pnpm = "10.12.3"
 
 [env]
   FORCE_COLOR = "1"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "turbo": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@10.12.2",
+  "packageManager": "pnpm@10.12.3",
   "prettier": "@2digits/prettier-config"
 }

--- a/packages/eslint-config/pnpm-lock.yaml
+++ b/packages/eslint-config/pnpm-lock.yaml
@@ -76,8 +76,8 @@ catalogs:
       specifier: 0.2.3
       version: 0.2.3
     eslint-plugin-jsdoc:
-      specifier: 51.2.2
-      version: 51.2.2
+      specifier: 51.2.3
+      version: 51.2.3
     eslint-plugin-jsonc:
       specifier: 2.20.1
       version: 2.20.1
@@ -100,8 +100,8 @@ catalogs:
       specifier: 3.0.3
       version: 3.0.3
     eslint-plugin-storybook:
-      specifier: 9.0.12
-      version: 9.0.12
+      specifier: 9.0.13
+      version: 9.0.13
     eslint-plugin-tailwindcss:
       specifier: 3.18.0
       version: 3.18.0
@@ -251,7 +251,7 @@ importers:
         version: 0.2.3(eslint@9.29.0(jiti@2.4.2))
       eslint-plugin-jsdoc:
         specifier: 'catalog:'
-        version: 51.2.2(eslint@9.29.0(jiti@2.4.2))
+        version: 51.2.3(eslint@9.29.0(jiti@2.4.2))
       eslint-plugin-jsonc:
         specifier: 'catalog:'
         version: 2.20.1(eslint@9.29.0(jiti@2.4.2))
@@ -275,7 +275,7 @@ importers:
         version: 3.0.3(eslint@9.29.0(jiti@2.4.2))
       eslint-plugin-storybook:
         specifier: 'catalog:'
-        version: 9.0.12(eslint@9.29.0(jiti@2.4.2))(storybook@9.0.12(@testing-library/dom@10.4.0))(typescript@5.8.3)
+        version: 9.0.13(eslint@9.29.0(jiti@2.4.2))(storybook@9.0.12(@testing-library/dom@10.4.0))(typescript@5.8.3)
       eslint-plugin-tailwindcss:
         specifier: 'catalog:'
         version: 3.18.0(tailwindcss@3.4.17)
@@ -1890,8 +1890,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-jsdoc@51.2.2:
-    resolution: {integrity: sha512-5e3VGUk3rvZ6ZuxJr5fCTVMj7TrMC80F1GbymjyUkplCbj6dXW41qX3ZzF8YULXM74cBfjnWy/nSp/I0eLl3vg==}
+  eslint-plugin-jsdoc@51.2.3:
+    resolution: {integrity: sha512-pagzxFubOih+O6XSB1D8BkDkJjF4G4/v8s9pRg4FkXQJLu0e3QJg621ayhmnhyc5mNBpp3cYCNiUyeLQs7oz7w==}
     engines: {node: '>=20.11.0'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
@@ -1999,12 +1999,12 @@ packages:
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0
 
-  eslint-plugin-storybook@9.0.12:
-    resolution: {integrity: sha512-dSzcozoI7tQRqfMODWfxahrRmKWsK88yKSUcO0+s361oYcX7nf8nEu99TQ/wuDLRHh+Zi7E2j43cPMH8gFo8OA==}
+  eslint-plugin-storybook@9.0.13:
+    resolution: {integrity: sha512-XnyE+3BmTe8jSzfHtPKTbzHkNpwrq2/e3Fy7l5Lr0NB1ykbblOCgS9kWWswX/1MQwFsEPt+TqRZvFhMX8tgy4g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       eslint: '>=8'
-      storybook: ^9.0.12
+      storybook: ^9.0.13
 
   eslint-plugin-tailwindcss@3.18.0:
     resolution: {integrity: sha512-PQDU4ZMzFH0eb2DrfHPpbgo87Zgg2EXSMOj1NSfzdZm+aJzpuwGerfowMIaVehSREEa0idbf/eoNYAOHSJoDAQ==}
@@ -3710,7 +3710,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.52.0':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.34.1
+      '@typescript-eslint/types': 8.35.0
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
@@ -5150,7 +5150,7 @@ snapshots:
       eslint: 9.29.0(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.29.0(jiti@2.4.2))
 
-  eslint-plugin-jsdoc@51.2.2(eslint@9.29.0(jiti@2.4.2)):
+  eslint-plugin-jsdoc@51.2.3(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
       '@es-joy/jsdoccomment': 0.52.0
       are-docs-informative: 0.0.2
@@ -5369,7 +5369,7 @@ snapshots:
       semver: 7.7.2
       typescript: 5.8.3
 
-  eslint-plugin-storybook@9.0.12(eslint@9.29.0(jiti@2.4.2))(storybook@9.0.12(@testing-library/dom@10.4.0))(typescript@5.8.3):
+  eslint-plugin-storybook@9.0.13(eslint@9.29.0(jiti@2.4.2))(storybook@9.0.12(@testing-library/dom@10.4.0))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.29.0(jiti@2.4.2)

--- a/packages/prettier-config/pnpm-lock.yaml
+++ b/packages/prettier-config/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 4.4.2
       version: 4.4.2
     '@prettier/plugin-oxc':
-      specifier: 0.0.3
-      version: 0.0.3
+      specifier: 0.0.4
+      version: 0.0.4
     '@prettier/plugin-xml':
       specifier: 3.4.1
       version: 3.4.1
@@ -71,7 +71,7 @@ importers:
         version: 4.4.2(prettier@3.6.0)
       '@prettier/plugin-oxc':
         specifier: 'catalog:'
-        version: 0.0.3
+        version: 0.0.4
       '@prettier/plugin-xml':
         specifier: 'catalog:'
         version: 3.4.1(prettier@3.6.0)
@@ -271,8 +271,8 @@ packages:
   '@oxc-project/types@0.74.0':
     resolution: {integrity: sha512-KOw/RZrVlHGhCXh1RufBFF7Nuo7HdY5w1lRJukM/igIl6x9qtz8QycDvZdzb4qnHO7znrPyo2sJrFJK2eKHgfQ==}
 
-  '@prettier/plugin-oxc@0.0.3':
-    resolution: {integrity: sha512-mtVlaFQA4Bq6flltVUUD0UaXwSWnDkQpcb5tkQColZzWb6tr4C27YGJpxIIUgKzJ0NrLxFrdcEkUgQXU/RJdtg==}
+  '@prettier/plugin-oxc@0.0.4':
+    resolution: {integrity: sha512-UGXe+g/rSRbglL0FOJiar+a+nUrst7KaFmsg05wYbKiInGWP6eAj/f8A2Uobgo5KxEtb2X10zeflNH6RK2xeIQ==}
     engines: {node: '>=14'}
 
   '@prettier/plugin-xml@3.4.1':
@@ -880,7 +880,7 @@ snapshots:
 
   '@oxc-project/types@0.74.0': {}
 
-  '@prettier/plugin-oxc@0.0.3':
+  '@prettier/plugin-oxc@0.0.4':
     dependencies:
       oxc-parser: 0.74.0
 

--- a/packages/renovate/pnpm-lock.yaml
+++ b/packages/renovate/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 1.0.44
       version: 1.0.44
     renovate:
-      specifier: 41.6.2
-      version: 41.6.2
+      specifier: 41.7.1
+      version: 41.7.1
     typescript:
       specifier: 5.8.3
       version: 5.8.3
@@ -53,7 +53,7 @@ importers:
         version: 1.0.44
       renovate:
         specifier: 'catalog:'
-        version: 41.6.2(encoding@0.1.13)(typanion@3.14.0)
+        version: 41.7.1(encoding@0.1.13)(typanion@3.14.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -2373,8 +2373,8 @@ packages:
   remark@15.0.1:
     resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
-  renovate@41.6.2:
-    resolution: {integrity: sha512-9M9VpVoflSnCg+rc07laig3oV21I+fYPogDjHwRIC0NOAYrkd6x6qYkSBxbqOlozHhdkWVlhT3Rx14g5E6MARA==}
+  renovate@41.7.1:
+    resolution: {integrity: sha512-sJdMGc+X3oPq8Tv8MWgKHNWlF2ho2qri7LWbXMDf6VOBzk371TCXvMYKQdOdiQMgNt7FkHN8xLwUlESaHmo3FA==}
     engines: {node: ^22.13.0, pnpm: ^10.0.0}
     hasBin: true
 
@@ -2844,8 +2844,8 @@ packages:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
 
-  zod@3.25.65:
-    resolution: {integrity: sha512-kMyE2qsXK1p+TAvO7zsf5wMFiCejU3obrUDs9bR1q5CBKykfvp7QhhXrycUylMoOow0iEUSyjLlZZdCsHwSldQ==}
+  zod@3.25.67:
+    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4023,7 +4023,7 @@ snapshots:
       fs-extra: 11.3.0
       toml-eslint-parser: 0.10.0
       upath: 2.0.1
-      zod: 3.25.65
+      zod: 3.25.67
 
   '@renovatebot/kbpgp@4.0.1':
     dependencies:
@@ -6136,7 +6136,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  renovate@41.6.2(encoding@0.1.13)(typanion@3.14.0):
+  renovate@41.7.1(encoding@0.1.13)(typanion@3.14.0):
     dependencies:
       '@aws-sdk/client-codecommit': 3.821.0
       '@aws-sdk/client-ec2': 3.821.0
@@ -6253,7 +6253,7 @@ snapshots:
       vuln-vects: 1.1.0
       xmldoc: 1.3.0
       yaml: 2.8.0
-      zod: 3.25.65
+      zod: 3.25.67
     optionalDependencies:
       better-sqlite3: 11.10.0
       openpgp: 6.1.1
@@ -6753,6 +6753,6 @@ snapshots:
 
   yocto-queue@1.2.1: {}
 
-  zod@3.25.65: {}
+  zod@3.25.67: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,7 @@ catalog:
   eslint-plugin-antfu: 3.1.1
   eslint-plugin-de-morgan: 1.3.0
   eslint-plugin-drizzle: 0.2.3
-  eslint-plugin-jsdoc: 51.2.2
+  eslint-plugin-jsdoc: 51.2.3
   eslint-plugin-jsonc: 2.20.1
   eslint-plugin-n: 17.20.0
   eslint-plugin-pnpm: 0.3.1
@@ -38,7 +38,7 @@ catalog:
   eslint-plugin-react-hooks: 5.2.0
   eslint-plugin-regexp: 2.9.0
   eslint-plugin-sonarjs: 3.0.3
-  eslint-plugin-storybook: 9.0.12
+  eslint-plugin-storybook: 9.0.13
   eslint-plugin-tailwindcss: 3.18.0
   eslint-plugin-turbo: 2.5.4
   eslint-plugin-unicorn: 59.0.1
@@ -59,7 +59,7 @@ catalog:
   prettier-plugin-jsdoc: 1.3.2
   prettier-plugin-tailwindcss: 0.6.13
   react: 19.1.0
-  renovate: 41.6.2
+  renovate: 41.7.1
   tinyglobby: 0.2.14
   ts-pattern: 5.7.1
   tsdown: 0.12.8
@@ -68,7 +68,7 @@ catalog:
   typescript-eslint: 8.35.0
   vitest: 3.2.4
   yaml-eslint-parser: 1.3.0
-  '@prettier/plugin-oxc': 0.0.3
+  '@prettier/plugin-oxc': 0.0.4
 
 catalogMode: strict
 


### PR DESCRIPTION
# Update dependencies

This PR updates several dependencies:

- Upgraded pnpm from 10.12.2 to 10.12.3 in mise.toml and package.json
- Updated ESLint plugins:
  - eslint-plugin-jsdoc from 51.2.2 to 51.2.3
  - eslint-plugin-storybook from 9.0.12 to 9.0.13
- Updated Prettier plugins:
  - @prettier/plugin-oxc from 0.0.3 to 0.0.4
- Updated Renovate from 41.6.2 to 41.7.1
- Added a changeset for patch updates to our config packages