### PR TITLE
⬆️ Update eslint-plugin-jsdoc, eslint-plugin-pnpm, and eslint-typegen dependencies

### DIFF
--- a/.changeset/chilly-cooks-try.md
+++ b/.changeset/chilly-cooks-try.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Updated dependencies

--- a/packages/eslint-config/pnpm-lock.yaml
+++ b/packages/eslint-config/pnpm-lock.yaml
@@ -76,8 +76,8 @@ catalogs:
       specifier: 0.2.3
       version: 0.2.3
     eslint-plugin-jsdoc:
-      specifier: 51.3.1
-      version: 51.3.1
+      specifier: 51.3.3
+      version: 51.3.3
     eslint-plugin-jsonc:
       specifier: 2.20.1
       version: 2.20.1
@@ -85,8 +85,8 @@ catalogs:
       specifier: 17.20.0
       version: 17.20.0
     eslint-plugin-pnpm:
-      specifier: 0.3.1
-      version: 0.3.1
+      specifier: 1.0.0
+      version: 1.0.0
     eslint-plugin-react-compiler:
       specifier: 19.1.0-rc.2
       version: 19.1.0-rc.2
@@ -115,8 +115,8 @@ catalogs:
       specifier: 1.18.0
       version: 1.18.0
     eslint-typegen:
-      specifier: 2.2.0
-      version: 2.2.0
+      specifier: 2.2.1
+      version: 2.2.1
     execa:
       specifier: 9.6.0
       version: 9.6.0
@@ -251,7 +251,7 @@ importers:
         version: 0.2.3(eslint@9.30.1(jiti@2.4.2))
       eslint-plugin-jsdoc:
         specifier: 'catalog:'
-        version: 51.3.1(eslint@9.30.1(jiti@2.4.2))
+        version: 51.3.3(eslint@9.30.1(jiti@2.4.2))
       eslint-plugin-jsonc:
         specifier: 'catalog:'
         version: 2.20.1(eslint@9.30.1(jiti@2.4.2))
@@ -260,7 +260,7 @@ importers:
         version: 17.20.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       eslint-plugin-pnpm:
         specifier: 'catalog:'
-        version: 0.3.1(eslint@9.30.1(jiti@2.4.2))
+        version: 1.0.0(eslint@9.30.1(jiti@2.4.2))
       eslint-plugin-react-compiler:
         specifier: 'catalog:'
         version: 19.1.0-rc.2(eslint@9.30.1(jiti@2.4.2))
@@ -327,7 +327,7 @@ importers:
         version: 9.30.1(jiti@2.4.2)
       eslint-typegen:
         specifier: 'catalog:'
-        version: 2.2.0(eslint@9.30.1(jiti@2.4.2))
+        version: 2.2.1(eslint@9.30.1(jiti@2.4.2))
       execa:
         specifier: 'catalog:'
         version: 9.6.0
@@ -1894,8 +1894,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-jsdoc@51.3.1:
-    resolution: {integrity: sha512-9v/e6XyrLf1HIs/uPCgm3GcUpH4BeuGVZJk7oauKKyS7su7d5Q6zx4Fq6TiYh+w7+b4Svy7ZWVCcNZJNx3y52w==}
+  eslint-plugin-jsdoc@51.3.3:
+    resolution: {integrity: sha512-8XK/9wncTh4PPntQfM4iYJ2v/kvX4qsfBzp+dTnyxpERWhl2R9hEJw1ihws+yAecg9CC6ExTfMInEg3wSK9kWA==}
     engines: {node: '>=20.11.0'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
@@ -1912,8 +1912,8 @@ packages:
     peerDependencies:
       eslint: '>=8.23.0'
 
-  eslint-plugin-pnpm@0.3.1:
-    resolution: {integrity: sha512-vi5iHoELIAlBbX4AW8ZGzU3tUnfxuXhC/NKo3qRcI5o9igbz6zJUqSlQ03bPeMqWIGTPatZnbWsNR1RnlNERNQ==}
+  eslint-plugin-pnpm@1.0.0:
+    resolution: {integrity: sha512-tyEA10k7psB9HFCx8R4/bU4JS2tSKfXaCnrCcis+1R4FucfMIc6HgcFl4msZbwY2I0D9Vec3xAEkXV0aPechhQ==}
     peerDependencies:
       eslint: ^9.0.0
 
@@ -2038,8 +2038,8 @@ packages:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint-typegen@2.2.0:
-    resolution: {integrity: sha512-OVgibKnRNnlSs4MhMz8uTRLSSIsvTXjH7a1gzXvyDIVU/txX1t8Zr9I/vOSwWIhtACX5DCPLo9CuyvA9usyjyw==}
+  eslint-typegen@2.2.1:
+    resolution: {integrity: sha512-DMx6fMxSsou1wiT2dviHvKRevCx6O7axogtl2WE0Pjq/p2D3rAx9ubsmQWMTmYyT/vmBWZ1yxZyAXhx1u7QpiA==}
     peerDependencies:
       eslint: ^9.0.0
 
@@ -2860,8 +2860,8 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
-  pnpm-workspace-yaml@0.3.1:
-    resolution: {integrity: sha512-3nW5RLmREmZ8Pm8MbPsO2RM+99RRjYd25ynj3NV0cFsN7CcEl4sDFzgoFmSyduFwxFQ2Qbu3y2UdCh6HlyUOeA==}
+  pnpm-workspace-yaml@1.0.0:
+    resolution: {integrity: sha512-2RKg3khFgX/oeKIQnxxlj+OUoKbaZjBt7EsmQiLfl8AHZKMIpLmXLRPptZ5eq2Rlumh2gILs6OWNky5dzP+f8A==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -3714,7 +3714,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.52.0':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.35.0
+      '@typescript-eslint/types': 8.35.1
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
@@ -5156,7 +5156,7 @@ snapshots:
       eslint: 9.30.1(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.30.1(jiti@2.4.2))
 
-  eslint-plugin-jsdoc@51.3.1(eslint@9.30.1(jiti@2.4.2)):
+  eslint-plugin-jsdoc@51.3.3(eslint@9.30.1(jiti@2.4.2)):
     dependencies:
       '@es-joy/jsdoccomment': 0.52.0
       are-docs-informative: 0.0.2
@@ -5203,13 +5203,13 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-pnpm@0.3.1(eslint@9.30.1(jiti@2.4.2)):
+  eslint-plugin-pnpm@1.0.0(eslint@9.30.1(jiti@2.4.2)):
     dependencies:
       eslint: 9.30.1(jiti@2.4.2)
       find-up-simple: 1.0.1
       jsonc-eslint-parser: 2.4.0
       pathe: 2.0.3
-      pnpm-workspace-yaml: 0.3.1
+      pnpm-workspace-yaml: 1.0.0
       tinyglobby: 0.2.14
       yaml-eslint-parser: 1.3.0
 
@@ -5434,7 +5434,7 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-typegen@2.2.0(eslint@9.30.1(jiti@2.4.2)):
+  eslint-typegen@2.2.1(eslint@9.30.1(jiti@2.4.2)):
     dependencies:
       eslint: 9.30.1(jiti@2.4.2)
       json-schema-to-typescript-lite: 14.1.0
@@ -6407,7 +6407,7 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  pnpm-workspace-yaml@0.3.1:
+  pnpm-workspace-yaml@1.0.0:
     dependencies:
       yaml: 2.8.0
 

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -2753,27 +2753,27 @@ Backward pagination arguments
   'padding-line-between-statements'?: Linter.RuleEntry<PaddingLineBetweenStatements>
   /**
    * Enforce using "catalog:" in `package.json`
-   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/json-enforce-catalog.test.ts
+   * @see https://github.com/antfu/pnpm-workspace-utils/tree/main/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.test.ts
    */
   'pnpm/json-enforce-catalog'?: Linter.RuleEntry<PnpmJsonEnforceCatalog>
   /**
    * Prefer having pnpm settings in `pnpm-workspace.yaml` instead of `package.json`. This would requires pnpm v10.6+, see https://github.com/orgs/pnpm/discussions/9037.
-   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/json-prefer-workspace-settings.test.ts
+   * @see https://github.com/antfu/pnpm-workspace-utils/tree/main/packages/eslint-plugin-pnpm/src/rules/json/json-prefer-workspace-settings.test.ts
    */
   'pnpm/json-prefer-workspace-settings'?: Linter.RuleEntry<PnpmJsonPreferWorkspaceSettings>
   /**
    * Enforce using valid catalog in `package.json`
-   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/json-valid-catalog.test.ts
+   * @see https://github.com/antfu/pnpm-workspace-utils/tree/main/packages/eslint-plugin-pnpm/src/rules/json/json-valid-catalog.test.ts
    */
   'pnpm/json-valid-catalog'?: Linter.RuleEntry<PnpmJsonValidCatalog>
   /**
    * Disallow unused catalogs in `pnpm-workspace.yaml`
-   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/yaml-no-duplicate-catalog-item.test.ts
+   * @see https://github.com/antfu/pnpm-workspace-utils/tree/main/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-duplicate-catalog-item.test.ts
    */
   'pnpm/yaml-no-duplicate-catalog-item'?: Linter.RuleEntry<PnpmYamlNoDuplicateCatalogItem>
   /**
    * Disallow unused catalogs in `pnpm-workspace.yaml`
-   * @see https://github.com/antfu/eslint-plugin-pnpm/blob/main/src/rules/yaml-no-unused-catalog-item.test.ts
+   * @see https://github.com/antfu/pnpm-workspace-utils/tree/main/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-unused-catalog-item.test.ts
    */
   'pnpm/yaml-no-unused-catalog-item'?: Linter.RuleEntry<[]>
   /**

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,10 +30,10 @@ catalog:
   eslint-plugin-antfu: 3.1.1
   eslint-plugin-de-morgan: 1.3.0
   eslint-plugin-drizzle: 0.2.3
-  eslint-plugin-jsdoc: 51.3.1
+  eslint-plugin-jsdoc: 51.3.3
   eslint-plugin-jsonc: 2.20.1
   eslint-plugin-n: 17.20.0
-  eslint-plugin-pnpm: 0.3.1
+  eslint-plugin-pnpm: 1.0.0
   eslint-plugin-react-compiler: 19.1.0-rc.2
   eslint-plugin-react-hooks: 5.2.0
   eslint-plugin-regexp: 2.9.0
@@ -43,7 +43,7 @@ catalog:
   eslint-plugin-turbo: 2.5.4
   eslint-plugin-unicorn: 59.0.1
   eslint-plugin-yml: 1.18.0
-  eslint-typegen: 2.2.0
+  eslint-typegen: 2.2.1
   eslint-vitest-rule-tester: 2.2.0
   execa: 9.6.0
   find-up: 7.0.0


### PR DESCRIPTION
# Update ESLint dependencies

This PR updates several ESLint plugin dependencies in the `@2digits/eslint-config` package:

- `eslint-plugin-jsdoc`: 51.3.1 → 51.3.3
- `eslint-plugin-pnpm`: 0.3.1 → 1.0.0
- `eslint-typegen`: 2.2.0 → 2.2.1

The types file has been updated to reflect the new documentation URLs for the PNPM plugin rules, which have moved to a new repository structure.

A changeset has been added to track this patch update.