### PR TITLE
🔧 Add GitHub Actions linting rules to eslint-config

### DIFF
--- a/.changeset/early-frogs-drive.md
+++ b/.changeset/early-frogs-drive.md
@@ -1,0 +1,5 @@
+---
+'@2digits/eslint-config': minor
+---
+
+Added new github actions linting rules

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-antfu": "catalog:",
     "eslint-plugin-de-morgan": "catalog:",
     "eslint-plugin-drizzle": "catalog:",
+    "eslint-plugin-github-action": "catalog:",
     "eslint-plugin-jsdoc": "catalog:",
     "eslint-plugin-jsonc": "catalog:",
     "eslint-plugin-n": "catalog:",

--- a/packages/eslint-config/pnpm-lock.yaml
+++ b/packages/eslint-config/pnpm-lock.yaml
@@ -75,6 +75,9 @@ catalogs:
     eslint-plugin-drizzle:
       specifier: 0.2.3
       version: 0.2.3
+    eslint-plugin-github-action:
+      specifier: 0.0.16
+      version: 0.0.16
     eslint-plugin-jsdoc:
       specifier: 51.3.3
       version: 51.3.3
@@ -249,6 +252,9 @@ importers:
       eslint-plugin-drizzle:
         specifier: 'catalog:'
         version: 0.2.3(eslint@9.30.1(jiti@2.4.2))
+      eslint-plugin-github-action:
+        specifier: 'catalog:'
+        version: 0.0.16(eslint@9.30.1(jiti@2.4.2))
       eslint-plugin-jsdoc:
         specifier: 'catalog:'
         version: 51.3.3(eslint@9.30.1(jiti@2.4.2))
@@ -1000,6 +1006,10 @@ packages:
   '@nolyfill/shared@1.0.44':
     resolution: {integrity: sha512-NI1zxDh4LYL7PYlKKCwojjuc5CEZslywrOTKBNyodjmWjRiZ4AlCMs3Gp+zDoPQPNkYCSQp/luNojHmJWWfCbw==}
 
+  '@ntnyq/utils@0.6.5':
+    resolution: {integrity: sha512-sjCzIYGXvRRuwN37twCVjszeDTfPtDE3hQ+vT/orH9Xo0ubKQDEA+HsyTewN1vo3ao0Kl3DGpsgPJ4nxy+nyvQ==}
+    engines: {node: '>=18.18.0'}
+
   '@oxc-project/runtime@0.73.2':
     resolution: {integrity: sha512-wbUN3K3zjMRHxAsNm1nKHebSnDY800b3LxQFTr9wSZpdQdhiQQAZpRIFsYjh0sAotoyqahN576sB1DmpPUhl5Q==}
     engines: {node: '>=6.9.0'}
@@ -1588,6 +1598,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
@@ -1893,6 +1906,12 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8'
+
+  eslint-plugin-github-action@0.0.16:
+    resolution: {integrity: sha512-eo7vvTZYpwfNbECYa67Lbg2xeM1Hcmh47CRK6AfqUFGxyouDKem7DQB9heopRMwk07bE4Ykkh5QEXRX3s12BVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.5.0
 
   eslint-plugin-jsdoc@51.3.3:
     resolution: {integrity: sha512-8XK/9wncTh4PPntQfM4iYJ2v/kvX4qsfBzp+dTnyxpERWhl2R9hEJw1ihws+yAecg9CC6ExTfMInEg3wSK9kWA==}
@@ -3303,6 +3322,10 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  uncase@0.1.0:
+    resolution: {integrity: sha512-xLz7Ekr0e+kNRy9lsxkaui5mZvDWlVMslLjacUPna7b4JrzHW3ZGsp9482bUoqIo0V7gDxSF2HxuKtABwo7SmA==}
+    engines: {node: '>=18.18.0'}
+
   unconfig@7.3.2:
     resolution: {integrity: sha512-nqG5NNL2wFVGZ0NA/aCFw0oJ2pxSf1lwg4Z5ill8wd7K4KX/rQbHlwbh+bjctXL5Ly1xtzHenHGOK0b+lG6JVg==}
 
@@ -4318,6 +4341,8 @@ snapshots:
 
   '@nolyfill/shared@1.0.44': {}
 
+  '@ntnyq/utils@0.6.5': {}
+
   '@oxc-project/runtime@0.73.2': {}
 
   '@oxc-project/types@0.73.2': {}
@@ -4900,6 +4925,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  change-case@5.4.4: {}
+
   character-entities@2.0.2: {}
 
   check-error@2.1.1: {}
@@ -5155,6 +5182,14 @@ snapshots:
       '@eslint-community/regexpp': 4.12.1
       eslint: 9.30.1(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.30.1(jiti@2.4.2))
+
+  eslint-plugin-github-action@0.0.16(eslint@9.30.1(jiti@2.4.2)):
+    dependencies:
+      '@ntnyq/utils': 0.6.5
+      '@types/json-schema': 7.0.15
+      eslint: 9.30.1(jiti@2.4.2)
+      uncase: 0.1.0
+      yaml-eslint-parser: 1.3.0
 
   eslint-plugin-jsdoc@51.3.3(eslint@9.30.1(jiti@2.4.2)):
     dependencies:
@@ -6865,6 +6900,10 @@ snapshots:
   typescript@5.8.3: {}
 
   ufo@1.6.1: {}
+
+  uncase@0.1.0:
+    dependencies:
+      change-case: 5.4.4
 
   unconfig@7.3.2:
     dependencies:

--- a/packages/eslint-config/src/configs/github-actions.ts
+++ b/packages/eslint-config/src/configs/github-actions.ts
@@ -1,0 +1,32 @@
+import parser from 'yaml-eslint-parser';
+import pluginGitHubAction from 'eslint-plugin-github-action';
+
+import { GLOB_GITHUB_ACTIONS } from '../globs';
+import type { TypedFlatConfigItem } from '../types';
+
+const recommendedRules = Object.fromEntries(
+  pluginGitHubAction.configs.recommended.flatMap(({ rules }) => Object.entries({ ...rules })),
+);
+
+export function githubActions(): Array<TypedFlatConfigItem> {
+  return [
+    {
+      name: '2digits:github-actions/setup',
+      plugins: {
+        'github-action': pluginGitHubAction,
+      },
+    },
+
+    {
+      name: '2digits:github-actions/recommended',
+      files: [GLOB_GITHUB_ACTIONS],
+      ignores: [`!**/${GLOB_GITHUB_ACTIONS}`],
+      languageOptions: {
+        parser,
+      },
+      rules: {
+        ...recommendedRules,
+      },
+    },
+  ];
+}

--- a/packages/eslint-config/src/configs/index.ts
+++ b/packages/eslint-config/src/configs/index.ts
@@ -3,6 +3,7 @@ export * from './boolean';
 export * from './comments';
 export * from './css';
 export * from './drizzle';
+export * from './github-actions';
 export * from './graphql';
 export * from './ignores';
 export * from './javascript';

--- a/packages/eslint-config/src/factory.ts
+++ b/packages/eslint-config/src/factory.ts
@@ -8,6 +8,7 @@ import {
   comments,
   css,
   drizzle,
+  githubActions,
   graphql,
   ignores,
   javascript,
@@ -104,6 +105,7 @@ export async function twoDigits(
     css(),
     yaml(),
     markdown(),
+    githubActions(),
   );
 
   if (enabled(options.turbo, isPackageExists('turbo'))) {

--- a/packages/eslint-config/src/globs.ts
+++ b/packages/eslint-config/src/globs.ts
@@ -13,6 +13,8 @@ export const GLOB_CSS = '**/*.css';
 
 export const GLOB_YAML = '**/*.y?(a)ml';
 
+export const GLOB_GITHUB_ACTIONS = '.github/workflows/*.y?(a)ml';
+
 export const GLOB_MARKDOWN = '**/*.md';
 export const GLOB_MARKDOWN_IN_MARKDOWN = '**/*.md/*.md';
 export const GLOB_MARKDOWN_CODE = `${GLOB_MARKDOWN}/${GLOB_SRC}`;

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -392,6 +392,81 @@ export interface RuleOptions {
    */
   'getter-return'?: Linter.RuleEntry<GetterReturn>
   /**
+   * enforce naming convention to action name.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/action-name-casing.html
+   */
+  'github-action/action-name-casing'?: Linter.RuleEntry<GithubActionActionNameCasing>
+  /**
+   * enforce naming convention to job id.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/job-id-casing.html
+   */
+  'github-action/job-id-casing'?: Linter.RuleEntry<GithubActionJobIdCasing>
+  /**
+   * enforce maximum jobs per action file.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/max-jobs-per-action.html
+   */
+  'github-action/max-jobs-per-action'?: Linter.RuleEntry<GithubActionMaxJobsPerAction>
+  /**
+   * disallow using external job.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/no-external-job.html
+   */
+  'github-action/no-external-job'?: Linter.RuleEntry<[]>
+  /**
+   * disallow using invalid key.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/no-invalid-key.html
+   */
+  'github-action/no-invalid-key'?: Linter.RuleEntry<[]>
+  /**
+   * disallow using top level env.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/no-top-level-env.html
+   */
+  'github-action/no-top-level-env'?: Linter.RuleEntry<[]>
+  /**
+   * disallow using top level permissions.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/no-top-level-permissions.html
+   */
+  'github-action/no-top-level-permissions'?: Linter.RuleEntry<[]>
+  /**
+   * enforce action file extension.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/prefer-file-extension.html
+   */
+  'github-action/prefer-file-extension'?: Linter.RuleEntry<GithubActionPreferFileExtension>
+  /**
+   * enforce the style of job step uses.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/prefer-step-uses-style.html
+   */
+  'github-action/prefer-step-uses-style'?: Linter.RuleEntry<GithubActionPreferStepUsesStyle>
+  /**
+   * require a string action name.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/require-action-name.html
+   */
+  'github-action/require-action-name'?: Linter.RuleEntry<[]>
+  /**
+   * require a string action run-name.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/require-action-run-name.html
+   */
+  'github-action/require-action-run-name'?: Linter.RuleEntry<[]>
+  /**
+   * require a string job name.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/require-job-name.html
+   */
+  'github-action/require-job-name'?: Linter.RuleEntry<[]>
+  /**
+   * require a string job step name.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/require-job-step-name.html
+   */
+  'github-action/require-job-step-name'?: Linter.RuleEntry<[]>
+  /**
+   * disallow invalid timeout-minutes.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/valid-timeout-minutes.html
+   */
+  'github-action/valid-timeout-minutes'?: Linter.RuleEntry<GithubActionValidTimeoutMinutes>
+  /**
+   * disallow invalid trigger events.
+   * @see https://eslint-plugin-github-action.ntnyq.com/rules/valid-trigger-events.html
+   */
+  'github-action/valid-trigger-events'?: Linter.RuleEntry<[]>
+  /**
    * Require `require()` calls to be placed at top-level module scope
    * @see https://eslint.org/docs/latest/rules/global-require
    * @deprecated
@@ -7685,6 +7760,66 @@ type GeneratorStarSpacing = []|[(("before" | "after" | "both" | "neither") | {
 type GetterReturn = []|[{
   allowImplicit?: boolean
 }]
+// ----- github-action/action-name-casing -----
+type GithubActionActionNameCasing = []|[(("camelCase" | "kebab-case" | "PascalCase" | "snake_case" | "Title Case" | "Train-Case" | "SCREAMING_SNAKE_CASE") | {
+  "kebab-case"?: boolean
+  camelCase?: boolean
+  PascalCase?: boolean
+  snake_case?: boolean
+  "Title Case"?: boolean
+  "Train-Case"?: boolean
+  SCREAMING_SNAKE_CASE?: boolean
+  
+  ignores?: string[]
+})]
+// ----- github-action/job-id-casing -----
+type GithubActionJobIdCasing = []|[(("camelCase" | "kebab-case" | "PascalCase" | "snake_case" | "Train-Case" | "SCREAMING_SNAKE_CASE") | {
+  "kebab-case"?: boolean
+  camelCase?: boolean
+  PascalCase?: boolean
+  snake_case?: boolean
+  "Train-Case"?: boolean
+  SCREAMING_SNAKE_CASE?: boolean
+  
+  ignores?: string[]
+})]
+// ----- github-action/max-jobs-per-action -----
+type GithubActionMaxJobsPerAction = []|[number]
+// ----- github-action/prefer-file-extension -----
+type GithubActionPreferFileExtension = []|[(("yml" | "yaml") | {
+  extension?: ("yml" | "yaml")
+  caseSensitive?: boolean
+})]
+// ----- github-action/prefer-step-uses-style -----
+type GithubActionPreferStepUsesStyle = []|[(("release" | "commit" | "branch") | {
+  commit?: boolean
+  release?: boolean
+  branch?: boolean
+  allowRepository?: boolean
+  allowDocker?: boolean
+  
+  ignores?: string[]
+})]
+// ----- github-action/valid-timeout-minutes -----
+type GithubActionValidTimeoutMinutes = []|[(number | {
+  
+  min?: number
+  
+  max?: number
+} | {
+  job?: (number | {
+    
+    min?: number
+    
+    max?: number
+  })
+  step?: (number | {
+    
+    min?: number
+    
+    max?: number
+  })
+})]
 // ----- gql/alphabetize -----
 type GqlAlphabetize = [{
   
@@ -13370,4 +13505,4 @@ type Yoda = []|[("always" | "never")]|[("always" | "never"), {
   onlyEquality?: boolean
 }]
 // Names of all the configs
-export type ConfigNames = '2digits:antfu' | '2digits:boolean' | '2digits:comments' | '2digits:css' | '2digits:drizzle' | '2digits:graphql' | '2digits:ignores' | '2digits:gitignore' | '2digits:javascript' | '2digits:jsdoc' | '2digits:jsonc/base' | '2digits:jsonc/base' | '2digits:jsonc/json' | '2digits:jsonc/jsonc' | '2digits:jsonc/json5' | '2digits:jsonc/package.json' | '2digits:jsonc/tsconfig.json' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:markdown/setup' | '2digits:markdown/processor' | '2digits:markdown/parser' | '2digits:markdown/rules' | '2digits:markdown/disables' | '2digits:next/setup' | '2digits:next/rules' | '2digits:node' | '2digits:pnpm/package-json' | '2digits:pnpm/pnpm-workspace-yaml' | '2digits:prettier' | '2digits:react/setup' | '2digits:react/rules' | '2digits:regexp' | '2digits:sonar' | '2digits:storybook/setup' | '2digits:storybook/rules' | '2digits:storybook/disables' | '2digits:storybook/config' | '2digits:tailwind' | '2digits:tanstack' | '2digits:turbo' | '2digits:typescript/setup' | '2digits:typescript/rules' | '2digits:typescript/disables/dts' | '2digits:typescript/disables/test' | '2digits:typescript/disables/cjs' | '2digits:unicorn' | '2digits:yaml/setup' | '2digits:yaml/base' | '2digits:yaml/recommended' | '2digits:yaml/standard' | '2digits:yaml/prettier'
+export type ConfigNames = '2digits:antfu' | '2digits:boolean' | '2digits:comments' | '2digits:css' | '2digits:drizzle' | '2digits:github-actions/setup' | '2digits:github-actions/recommended' | '2digits:graphql' | '2digits:ignores' | '2digits:gitignore' | '2digits:javascript' | '2digits:jsdoc' | '2digits:jsonc/base' | '2digits:jsonc/base' | '2digits:jsonc/json' | '2digits:jsonc/jsonc' | '2digits:jsonc/json5' | '2digits:jsonc/package.json' | '2digits:jsonc/tsconfig.json' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:jsonc/prettier' | '2digits:markdown/setup' | '2digits:markdown/processor' | '2digits:markdown/parser' | '2digits:markdown/rules' | '2digits:markdown/disables' | '2digits:next/setup' | '2digits:next/rules' | '2digits:node' | '2digits:pnpm/package-json' | '2digits:pnpm/pnpm-workspace-yaml' | '2digits:prettier' | '2digits:react/setup' | '2digits:react/rules' | '2digits:regexp' | '2digits:sonar' | '2digits:storybook/setup' | '2digits:storybook/rules' | '2digits:storybook/disables' | '2digits:storybook/config' | '2digits:tailwind' | '2digits:tanstack' | '2digits:turbo' | '2digits:typescript/setup' | '2digits:typescript/rules' | '2digits:typescript/disables/dts' | '2digits:typescript/disables/test' | '2digits:typescript/disables/cjs' | '2digits:unicorn' | '2digits:yaml/setup' | '2digits:yaml/base' | '2digits:yaml/recommended' | '2digits:yaml/standard' | '2digits:yaml/prettier'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,6 +69,7 @@ catalog:
   vitest: 3.2.4
   yaml-eslint-parser: 1.3.0
   '@prettier/plugin-oxc': 0.0.4
+  eslint-plugin-github-action: 0.0.16
 
 catalogMode: strict
 


### PR DESCRIPTION
# Added GitHub Actions Linting Rules

This PR adds support for linting GitHub Actions workflow files by integrating the `eslint-plugin-github-action` package. The implementation includes:

- Added a new GitHub Actions configuration module with recommended rules
- Created a glob pattern specifically for GitHub workflow files
- Integrated the GitHub Actions linting into the main ESLint configuration factory
- Added appropriate type definitions for the new rules

The plugin enforces best practices for GitHub Actions workflows, including:
- Naming conventions for actions and jobs
- Validation of timeout values and trigger events
- Prevention of invalid keys and external job usage
- Enforcement of consistent styling for step uses

A changeset has been included to mark this as a minor version update to the `@2digits/eslint-config` package.