### PR TITLE
🔧 Update changesets config schema URL

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": true,
   "fixed": [],


### PR DESCRIPTION
Updated the `$schema` URL in the Changesets configuration to use a version-agnostic path, removing the explicit version number `2.3.0` from the URL. This change ensures the schema reference remains valid regardless of Changesets version updates.