### PR TITLE
📦 Add @2digits/cli package with tailwind functions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@2digits/cli",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/2digits-agency/configs.git",
+    "directory": "packages/cli"
+  },
+  "type": "module",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "bin": {
+    "2d": "./dist/bin.mjs"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": "./dist/index.mjs",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsdown --minify",
+    "dev": "tsdown --watch",
+    "types": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "public": true,
+  "devDependencies": {
+    "@2digits/tsconfig": "workspace:*",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,1 @@
+export const tailwindFunctions = ['tv', 'cn', 'cnBase', 'classnames', 'clsx', 'cx'];

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@2digits/tsconfig/tsconfig.json",
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+
+  dts: true,
+  fixedExtension: true,
+  exports: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,18 @@ importers:
         specifier: 'catalog:'
         version: 5.9.2
 
+  packages/cli:
+    devDependencies:
+      '@2digits/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.14.2(patch_hash=d0b372a605331e51cd90a8230410958d5f866f59c93dcd7c5ea3a02ba4422eaf)(oxc-resolver@11.6.2)(typescript@5.9.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
   packages/constants:
     devDependencies:
       '@2digits/tsconfig':


### PR DESCRIPTION
# Add CLI Package with Tailwind Functions Export

This PR introduces a new `@2digits/cli` package that exports a list of Tailwind utility function names. The package is set up with:

- A basic package structure with TypeScript configuration
- An export of `tailwindFunctions` array containing common Tailwind utility function names (`tv`, `cn`, `cnBase`, etc.)
- Configuration for building with tsdown
- Proper package.json setup with bin entry for a `2d` CLI command

The package is configured to build to ESM format and includes type definitions.