### PR TITLE
🔧 Fix CLI package exports and add dependency installation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,9 +8,9 @@
     "directory": "packages/cli"
   },
   "type": "module",
-  "main": "./dist/index.mjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "main": "./dist/bin.mjs",
+  "module": "./dist/bin.mjs",
+  "types": "./dist/bin.d.mts",
   "bin": {
     "2d": "./dist/bin.mjs"
   },
@@ -18,8 +18,7 @@
     "dist"
   ],
   "exports": {
-    ".": "./dist/index.mjs",
-    "./bin": "./dist/bin.mjs",
+    ".": "./dist/bin.mjs",
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/packages/cli/src/services/PrettierSetupService.ts
+++ b/packages/cli/src/services/PrettierSetupService.ts
@@ -32,11 +32,13 @@ export class PrettierSetupService extends Effect.Service<PrettierSetupService>()
 
       yield* pm.writePackageJson({ id: root, content: packageJson });
 
-      yield* Effect.logFatal('TODO: Install dependencies (prettier, @2digits/prettier-config)');
+      yield* pm.addDependencies({
+        devDependencies: ['prettier', '@2digits/prettier-config'],
+      });
 
       yield* Effect.logInfo('🎉 Prettier setup complete!');
-      yield* Effect.logInfo("Run 'npm run format' to check formatting");
-      yield* Effect.logInfo("Run 'npm run format:fix' to fix formatting issues");
+      yield* Effect.logInfo("Run '" + " format' to check formatting");
+      yield* Effect.logInfo("Run '" + " format:fix' to fix formatting issues");
     });
 
     return {

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -4,7 +4,7 @@ import Replace from 'unplugin-replace';
 import pkg from './package.json';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/bin.ts'],
+  entry: ['src/bin.ts'],
 
   dts: true,
   fixedExtension: true,


### PR DESCRIPTION
# CLI Package Refactoring and Dependency Management Improvements

This PR makes several important changes to the CLI package:

1. Simplifies the package exports by making `bin.mjs` the main entry point instead of having separate `index.mjs` and `bin.mjs` files
2. Updates the tsdown configuration to only build the `bin.ts` entry point
3. Adds dependency management functionality to `PackageManagerService` using the `nypm` library:
   - Implements `addDependencies` method to install dependencies and devDependencies
   - Supports workspace-specific dependency installation

4. Fixes the `PrettierSetupService` to automatically install required dependencies:
   - Now installs `prettier` and `@2digits/prettier-config` as devDependencies
   - Updates the path handling in package.json operations

These changes streamline the CLI package structure and improve the developer experience by automating dependency installation.