### PR TITLE
Setup monorepo typescript, eslint, and turborepo

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,8 @@
     "@effect/platform-node": "catalog:",
     "effect": "catalog:",
     "nypm": "catalog:",
-    "pkg-types": "catalog:"
+    "pkg-types": "catalog:",
+    "tinyglobby": "catalog:"
   },
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -2,7 +2,10 @@ import { Command, Options } from '@effect/cli';
 import { Console, Effect, Option } from 'effect';
 
 import { moduleVersion } from './internal/version';
+import { ESLintSetupService } from './services/ESLintSetupService';
 import { PrettierSetupService } from './services/PrettierSetupService';
+import { TurboSetupService } from './services/TurboSetupService';
+import { TypeScriptSetupService } from './services/TypeScriptSetupService';
 
 const command = Command.make('2d', {
   prettier: Options.boolean('prettier').pipe(
@@ -10,19 +13,56 @@ const command = Command.make('2d', {
     Options.withDefault(Option.some(true)),
     Options.withDescription('Setup Prettier with @2digits/prettier-config'),
   ),
+  typescript: Options.boolean('ts').pipe(
+    Options.optional,
+    Options.withDefault(Option.some(true)),
+    Options.withDescription('Setup TypeScript tsconfig and types script for all workspaces'),
+  ),
+  eslint: Options.boolean('eslint').pipe(
+    Options.optional,
+    Options.withDefault(Option.some(true)),
+    Options.withDescription('Setup ESLint and @2digits/eslint-config for all workspaces'),
+  ),
+  turbo: Options.boolean('turbo').pipe(
+    Options.optional,
+    Options.withDefault(Option.some(true)),
+    Options.withDescription('Setup Turborepo in the root with default tasks and scripts'),
+  ),
 }).pipe(
   Command.withDescription('Setup the 2DIGITS configs in your project'),
   Command.withHandler(
     Effect.fn('2d')(
-      function* ({ prettier }) {
+      function* ({ prettier, typescript, eslint, turbo }) {
         if (Option.isNone(prettier) || !prettier.value) {
           yield* Effect.logDebug('Setting up Prettier...');
-
           const setupService = yield* PrettierSetupService;
-
           yield* setupService.setup();
         } else {
           yield* Effect.logDebug('Skipping Prettier setup');
+        }
+
+        if (Option.isNone(typescript) || !typescript.value) {
+          yield* Effect.logDebug('Setting up TypeScript...');
+          const tsService = yield* TypeScriptSetupService;
+          yield* tsService.setup();
+        } else {
+          yield* Effect.logDebug('Skipping TypeScript setup');
+        }
+
+        if (Option.isNone(eslint) || !eslint.value) {
+          yield* Effect.logDebug('Setting up ESLint...');
+          const esService = yield* ESLintSetupService;
+          yield* esService.setup();
+        } else {
+          yield* Effect.logDebug('Skipping ESLint setup');
+        }
+
+        if (Option.isNone(turbo) || !turbo.value) {
+          yield* Effect.logDebug('Setting up Turborepo...');
+          const tbService = yield* TurboSetupService;
+          yield* tbService.setup();
+        } else {
+          yield* Effect.logDebug('Skipping Turborepo setup');
         }
       },
       Effect.tap((options) => Console.log(`Running 2DIGITS Configuration CLI ${moduleVersion} with options:`, options)),

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -4,8 +4,20 @@ import { NodeContext, NodeRuntime } from '@effect/platform-node';
 import { Effect, Layer } from 'effect';
 
 import { cli } from './Cli';
+import { ESLintSetupService } from './services/ESLintSetupService';
 import { PrettierSetupService } from './services/PrettierSetupService';
+import { TurboSetupService } from './services/TurboSetupService';
+import { TypeScriptSetupService } from './services/TypeScriptSetupService';
+import { WorkspaceService } from './services/WorkspaceService';
 
-const MainLive = Layer.mergeAll(CliConfig.layer(), PrettierSetupService.Default, NodeContext.layer);
+const MainLive = Layer.mergeAll(
+  CliConfig.layer(),
+  PrettierSetupService.Default,
+  WorkspaceService.Default,
+  TypeScriptSetupService.Default,
+  ESLintSetupService.Default,
+  TurboSetupService.Default,
+  NodeContext.layer,
+);
 
 cli(process.argv).pipe(Effect.provide(MainLive), NodeRuntime.runMain);

--- a/packages/cli/src/services/ESLintSetupService.ts
+++ b/packages/cli/src/services/ESLintSetupService.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { Effect } from 'effect';
+
+import { PackageManagerService } from './PackageManagerService';
+import { WorkspaceService } from './WorkspaceService';
+
+export class ESLintSetupService extends Effect.Service<ESLintSetupService>()('ESLintSetupService', {
+  effect: Effect.gen(function* () {
+    const pm = yield* PackageManagerService;
+    const ws = yield* WorkspaceService;
+
+    const ensureEslintConfig = Effect.fn('ESLintSetupService.ensureEslintConfig')(function* (packageDir: string) {
+      const configPath = path.resolve(packageDir, 'eslint.config.ts');
+      const content = `import twoDigits from '@2digits/eslint-config';
+
+export default twoDigits({ ts: true, turbo: true, pnpm: true });
+`;
+
+      yield* Effect.tryPromise({
+        try: () => fs.writeFile(configPath, content, 'utf8'),
+        catch: (cause) => cause,
+      });
+    });
+
+    const ensureLintScripts = Effect.fn('ESLintSetupService.ensureLintScripts')(function* (packageDir: string) {
+      const pkg = yield* pm.readPackageJson({ id: packageDir });
+      pkg.scripts = pkg.scripts ?? {};
+      if (!pkg.scripts.lint) pkg.scripts.lint = 'eslint .';
+      if (!pkg.scripts['lint:fix']) pkg.scripts['lint:fix'] = 'eslint . --fix';
+      yield* pm.writePackageJson({ id: packageDir, content: pkg });
+    });
+
+    const installDeps = Effect.fn('ESLintSetupService.installDeps')(function* () {
+      yield* pm.addDependencies({ devDependencies: ['eslint', '@2digits/eslint-config'] });
+    });
+
+    const setup = Effect.fn('ESLintSetupService.setup')(function* () {
+      yield* Effect.logInfo('🧹 Setting up ESLint across workspaces...');
+
+      const packageDirs = yield* ws.listPackageDirs();
+      for (const dir of packageDirs) {
+        yield* ensureEslintConfig(dir);
+        yield* ensureLintScripts(dir);
+      }
+
+      yield* installDeps();
+
+      yield* Effect.logInfo('✅ ESLint setup complete');
+    });
+
+    return { setup };
+  }),
+  dependencies: [PackageManagerService.Default, WorkspaceService.Default],
+}) {}
+

--- a/packages/cli/src/services/TurboSetupService.ts
+++ b/packages/cli/src/services/TurboSetupService.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { Effect } from 'effect';
+
+import { PackageManagerService } from './PackageManagerService';
+
+export class TurboSetupService extends Effect.Service<TurboSetupService>()('TurboSetupService', {
+  effect: Effect.gen(function* () {
+    const pm = yield* PackageManagerService;
+
+    const ensureRootScripts = Effect.fn('TurboSetupService.ensureRootScripts')(function* () {
+      const root = yield* pm.resolveRoot();
+      const rootPkg = yield* pm.readPackageJson({ id: root });
+      rootPkg.scripts = rootPkg.scripts ?? {};
+      rootPkg.scripts.types = rootPkg.scripts.types ?? 'turbo types';
+      rootPkg.scripts.lint = rootPkg.scripts.lint ?? 'turbo run lint';
+      rootPkg.scripts['lint:fix'] = rootPkg.scripts['lint:fix'] ?? 'turbo run lint -- --fix';
+      yield* pm.writePackageJson({ id: root, content: rootPkg });
+    });
+
+    const ensureTurboJson = Effect.fn('TurboSetupService.ensureTurboJson')(function* () {
+      const root = yield* pm.resolveRoot();
+      const turboPath = path.resolve(root, 'turbo.json');
+      const content = JSON.stringify(
+        {
+          tasks: {
+            build: { dependsOn: ['^build'], outputs: ['dist/**'] },
+            types: { dependsOn: ['^types', 'build', '^build'], outputs: ['tsconfig.tsbuildinfo'] },
+            lint: {},
+          },
+        },
+        null,
+        2,
+      ) + '\n';
+      yield* Effect.tryPromise({
+        try: () => fs.writeFile(turboPath, content, 'utf8'),
+        catch: (cause) => cause,
+      });
+    });
+
+    const installDeps = Effect.fn('TurboSetupService.installDeps')(function* () {
+      yield* pm.addDependencies({ devDependencies: ['turbo'] });
+    });
+
+    const setup = Effect.fn('TurboSetupService.setup')(function* () {
+      yield* Effect.logInfo('📦 Setting up Turborepo in root...');
+      yield* ensureTurboJson();
+      yield* ensureRootScripts();
+      yield* installDeps();
+      yield* Effect.logInfo('✅ Turborepo setup complete');
+    });
+
+    return { setup };
+  }),
+  dependencies: [PackageManagerService.Default],
+}) {}
+

--- a/packages/cli/src/services/TypeScriptSetupService.ts
+++ b/packages/cli/src/services/TypeScriptSetupService.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { Effect, Option } from 'effect';
+
+import { PackageManagerService } from './PackageManagerService';
+import { WorkspaceService } from './WorkspaceService';
+
+export class TypeScriptSetupService extends Effect.Service<TypeScriptSetupService>()('TypeScriptSetupService', {
+  effect: Effect.gen(function* () {
+    const pm = yield* PackageManagerService;
+    const ws = yield* WorkspaceService;
+
+    const ensureTsconfigForPackage = Effect.fn('TypeScriptSetupService.ensureTsconfigForPackage')(function* (
+      packageDir: string,
+    ) {
+      const tsconfigPath = path.resolve(packageDir, 'tsconfig.json');
+      const template = {
+        extends: '@2digits/tsconfig/tsconfig.json',
+        compilerOptions: {
+          plugins: [{ name: '@effect/language-service' }],
+        },
+        include: ['**/*.ts', '**/*.tsx'],
+        exclude: ['dist', 'node_modules'],
+      } as const;
+
+      // read & update/overwrite
+      const content = JSON.stringify(template, null, 2) + '\n';
+      yield* Effect.tryPromise({
+        try: () => fs.writeFile(tsconfigPath, content, 'utf8'),
+        catch: (cause) => cause,
+      });
+    });
+
+    const ensureTypesScript = Effect.fn('TypeScriptSetupService.ensureTypesScript')(function* (packageDir: string) {
+      const pkg = yield* pm.readPackageJson({ id: packageDir });
+      pkg.scripts = pkg.scripts ?? {};
+      if (!pkg.scripts.types) {
+        pkg.scripts.types = 'tsc --noEmit';
+      }
+      yield* pm.writePackageJson({ id: packageDir, content: pkg });
+    });
+
+    const installDeps = Effect.fn('TypeScriptSetupService.installDeps')(function* () {
+      yield* pm.addDependencies({ devDependencies: ['typescript', '@2digits/tsconfig', '@effect/language-service'] });
+    });
+
+    const setup = Effect.fn('TypeScriptSetupService.setup')(function* () {
+      yield* Effect.logInfo('🛠️ Setting up TypeScript across workspaces...');
+
+      const packageDirs = yield* ws.listPackageDirs();
+
+      for (const dir of packageDirs) {
+        yield* ensureTsconfigForPackage(dir);
+        yield* ensureTypesScript(dir);
+      }
+
+      // Root tsconfig for references or tooling consistency
+      const root = yield* pm.resolveRoot();
+      const rootTsConfigPath = path.resolve(root, 'tsconfig.json');
+      const rootTemplate = {
+        extends: '@2digits/tsconfig/tsconfig.json',
+        compilerOptions: {
+          plugins: [{ name: '@effect/language-service' }],
+        },
+        include: ['**/*.ts', '**/*.tsx'],
+        exclude: ['dist', 'node_modules'],
+      } as const;
+      yield* Effect.tryPromise({
+        try: () => fs.writeFile(rootTsConfigPath, JSON.stringify(rootTemplate, null, 2) + '\n', 'utf8'),
+        catch: (cause) => cause,
+      });
+
+      yield* installDeps();
+
+      yield* Effect.logInfo('✅ TypeScript setup complete');
+    });
+
+    return { setup };
+  }),
+  dependencies: [PackageManagerService.Default, WorkspaceService.Default],
+}) {}
+

--- a/packages/cli/src/services/WorkspaceService.ts
+++ b/packages/cli/src/services/WorkspaceService.ts
@@ -1,0 +1,109 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { Path } from '@effect/platform';
+import fg from 'tinyglobby';
+import { Array, Data, Effect, Option, String } from 'effect';
+
+import { PackageManagerService } from './PackageManagerService';
+
+class WorkspaceError extends Data.TaggedError('WorkspaceError')<{
+  cause: unknown;
+  message?: string;
+}> {}
+
+export class WorkspaceService extends Effect.Service<WorkspaceService>()('WorkspaceService', {
+  effect: Effect.gen(function* () {
+    const pm = yield* PackageManagerService;
+    const effPath = yield* Path.Path;
+
+    const readFileIfExists = (filePath: string) =>
+      Effect.tryPromise({
+        try: async () => {
+          try {
+            return await fs.readFile(filePath, 'utf8');
+          } catch (error) {
+            return undefined;
+          }
+        },
+        catch: (cause) => new WorkspaceError({ cause }),
+      });
+
+    const getWorkspaceGlobs = Effect.fn('WorkspaceService.getWorkspaceGlobs')(function* () {
+      const root = yield* pm.resolveRoot();
+
+      const pkg = yield* pm.readPackageJson({ id: root });
+
+      let globs: Array<string> = [];
+
+      // yarn/npm style workspaces in package.json
+      if (Array.isArray((pkg as any).workspaces)) {
+        globs = (pkg as any).workspaces as Array<string>;
+      } else if (typeof (pkg as any).workspaces === 'object' && Array.isArray((pkg as any).workspaces?.packages)) {
+        globs = (pkg as any).workspaces.packages as Array<string>;
+      }
+
+      // pnpm style workspaces in pnpm-workspace.yaml
+      if (Array.isEmptyArray(globs)) {
+        const yamlContent = yield* readFileIfExists(path.resolve(root, 'pnpm-workspace.yaml'));
+
+        if (yamlContent) {
+          const lines = yamlContent.split('\n');
+          const collected: Array<string> = [];
+          let inPackages = false;
+          for (const raw of lines) {
+            const line = raw.trimEnd();
+            if (line.startsWith('packages:')) {
+              inPackages = true;
+              continue;
+            }
+            if (inPackages) {
+              const trimmed = line.trim();
+              if (trimmed.startsWith('- ')) {
+                const glob = trimmed.slice(2).trim();
+                if (glob && !glob.startsWith('#')) collected.push(glob);
+              } else if (!trimmed || trimmed.startsWith('#')) {
+                // continue
+              } else if (!line.startsWith(' ')) {
+                // left the packages block
+                inPackages = false;
+              }
+            }
+          }
+          if (Array.isNonEmptyArray(collected)) globs = collected;
+        }
+      }
+
+      if (Array.isEmptyArray(globs)) {
+        // fallbacks commonly used in monorepos
+        globs = ['packages/*', 'apps/*'];
+      }
+
+      return { root, globs } as const;
+    });
+
+    const listPackageDirs = Effect.fn('WorkspaceService.listPackageDirs')(function* () {
+      const { root, globs } = yield* getWorkspaceGlobs();
+
+      const patterns = globs.map((g) => path.join(g, 'package.json'));
+
+      const files = yield* Effect.tryPromise({
+        try: () => fg(patterns, { cwd: root, onlyFiles: true, dot: true }),
+        catch: (cause) => new WorkspaceError({ cause }),
+      });
+
+      const dirs = files
+        .map((f) => path.resolve(root, path.dirname(f)))
+        .filter((p) => p !== root);
+
+      return Array.dedupeWith(dirs, (a, b) => String.Eq.equals(a, b));
+    });
+
+    return {
+      getWorkspaceGlobs,
+      listPackageDirs,
+    };
+  }),
+  dependencies: [PackageManagerService.Default, Path.layer],
+}) {}
+


### PR DESCRIPTION
Adds CLI commands to automate TypeScript, ESLint, and Turborepo setup across monorepo packages, extending `@2digits` configurations.

This PR introduces new CLI flags (`--ts`, `--eslint`, `--turbo`) to streamline the initial setup and ongoing maintenance of these tools in a monorepo, ensuring consistency with `@2digits` standards and providing essential development scripts.

---

<a href="https://cursor.com/background-agent?bcId=bc-2ff1a426-9bc2-4402-b994-84e97a0348d9"></a>

```
<img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
```


<a href="https://cursor.com/agents?id=bc-2ff1a426-9bc2-4402-b994-84e97a0348d9"></a>

```
<img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
```



