### PR TITLE
⬆️ Upgrade GitHub Actions and optimize PNPM caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,14 @@ jobs:
       - name: 🗃️ Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
+      - name: 🛸 Setup PNPM
+        uses: pnpm/action-setup@v4
+
       - name: 🏭 Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22.19.0
-
-      - name: 🛸 Setup PNPM
-        uses: pnpm/action-setup@v3
+          cache: pnpm
 
       - name: 📂 Get pnpm store directory
         shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,13 +22,14 @@ jobs:
       - name: 🗃️ Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
+      - name: 🛸 Setup PNPM
+        uses: pnpm/action-setup@v4
+
       - name: 🏭 Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22.19.0
-
-      - name: 🛸 Setup PNPM
-        uses: pnpm/action-setup@v3
+          cache: pnpm
 
       - name: 📂 Get pnpm store directory
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,14 @@ jobs:
       - name: 🗃️ Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
+      - name: 🛸 Setup PNPM
+        uses: pnpm/action-setup@v4
+
       - name: 🏭 Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22.19.0
-
-      - name: 🛸 Setup PNPM
-        uses: pnpm/action-setup@v3
+          cache: pnpm
 
       - name: 📂 Get pnpm store directory
         shell: bash


### PR DESCRIPTION
# Update GitHub Actions Workflows for Node and PNPM

This PR updates our GitHub Actions workflows with the following improvements:

1. Upgrades `pnpm/action-setup` from v3 to v4
2. Upgrades `actions/setup-node` from v4 to v5 (with updated SHA)
3. Reorders the setup steps to install PNPM before Node
4. Enables built-in PNPM caching in the Node setup action by adding `cache: pnpm`

These changes will improve our CI/CD pipeline efficiency by leveraging the native caching capabilities in the latest Node setup action.