### PR TITLE
Setup vscode eslint prettier cli integration

### DIFF
--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -3,6 +3,7 @@ import { Console, Effect, Option } from 'effect';
 
 import { moduleVersion } from './internal/version';
 import { PrettierSetupService } from './services/PrettierSetupService';
+import { VSCodeSetupService } from './services/VSCodeSetupService';
 
 const command = Command.make('2d', {
   prettier: Options.boolean('prettier').pipe(
@@ -10,11 +11,16 @@ const command = Command.make('2d', {
     Options.withDefault(Option.some(true)),
     Options.withDescription('Setup Prettier with @2digits/prettier-config'),
   ),
+  vscode: Options.boolean('vscode').pipe(
+    Options.optional,
+    Options.withDefault(Option.some(true)),
+    Options.withDescription('Setup VSCode settings and extension recommendations (.vscode/*)'),
+  ),
 }).pipe(
   Command.withDescription('Setup the 2DIGITS configs in your project'),
   Command.withHandler(
     Effect.fn('2d')(
-      function* ({ prettier }) {
+      function* ({ prettier, vscode }) {
         if (Option.isNone(prettier) || !prettier.value) {
           yield* Effect.logDebug('Setting up Prettier...');
 
@@ -23,6 +29,15 @@ const command = Command.make('2d', {
           yield* setupService.setup();
         } else {
           yield* Effect.logDebug('Skipping Prettier setup');
+        }
+
+        if (Option.isNone(vscode) || !vscode.value) {
+          yield* Effect.logDebug('Setting up VSCode...');
+
+          const vscodeService = yield* VSCodeSetupService;
+          yield* vscodeService.setup();
+        } else {
+          yield* Effect.logDebug('Skipping VSCode setup');
         }
       },
       Effect.tap((options) => Console.log(`Running 2DIGITS Configuration CLI ${moduleVersion} with options:`, options)),

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -5,7 +5,13 @@ import { Effect, Layer } from 'effect';
 
 import { cli } from './Cli';
 import { PrettierSetupService } from './services/PrettierSetupService';
+import { VSCodeSetupService } from './services/VSCodeSetupService';
 
-const MainLive = Layer.mergeAll(CliConfig.layer(), PrettierSetupService.Default, NodeContext.layer);
+const MainLive = Layer.mergeAll(
+  CliConfig.layer(),
+  PrettierSetupService.Default,
+  VSCodeSetupService.Default,
+  NodeContext.layer,
+);
 
 cli(process.argv).pipe(Effect.provide(MainLive), NodeRuntime.runMain);

--- a/packages/cli/src/services/VSCodeSetupService.ts
+++ b/packages/cli/src/services/VSCodeSetupService.ts
@@ -1,0 +1,110 @@
+import { Path } from '@effect/platform';
+import { Effect } from 'effect';
+import * as fs from 'node:fs/promises';
+
+import { PackageManagerService } from './PackageManagerService';
+
+export class VSCodeSetupService extends Effect.Service<VSCodeSetupService>()('VSCodeSetupService', {
+  effect: Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const pm = yield* PackageManagerService;
+
+    const ensureDirectory = (dirPath: string) =>
+      Effect.tryPromise({
+        try: async () => {
+          try {
+            await fs.mkdir(dirPath, { recursive: true });
+          } catch (error) {
+            // Ignore EEXIST
+            if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+          }
+        },
+        catch: (cause) => cause,
+      });
+
+    const readJsonIfExists = <T>(filePath: string) =>
+      Effect.tryPromise({
+        try: async () => {
+          try {
+            const content = await fs.readFile(filePath, 'utf8');
+            return JSON.parse(content) as T;
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined as unknown as T;
+            throw error;
+          }
+        },
+        catch: (cause) => cause,
+      });
+
+    const writeJson = (filePath: string, data: unknown) =>
+      Effect.tryPromise({
+        try: async () => {
+          const json = JSON.stringify(data, null, 2) + '\n';
+          await fs.writeFile(filePath, json, 'utf8');
+        },
+        catch: (cause) => cause,
+      });
+
+    const setup = Effect.fn('VSCodeSetupService.setup')(function* () {
+      yield* Effect.logInfo('🛠️  Configuring VS Code settings...');
+
+      const root = yield* pm.resolveRoot();
+      const vscodeDir = path.resolve(root, '.vscode');
+      const settingsPath = path.resolve(vscodeDir, 'settings.json');
+      const extensionsPath = path.resolve(vscodeDir, 'extensions.json');
+
+      yield* ensureDirectory(vscodeDir);
+
+      // Desired settings to enforce good ESLint + Prettier VSCode behavior
+      const desiredSettings: Record<string, unknown> = {
+        'editor.defaultFormatter': 'esbenp.prettier-vscode',
+        'editor.formatOnSave': true,
+        'editor.codeActionsOnSave': {
+          'source.fixAll': 'explicit',
+          'source.fixAll.eslint': 'explicit',
+        },
+        'eslint.useFlatConfig': true,
+        'eslint.experimental.useFlatConfig': true,
+        'eslint.workingDirectories': [{ mode: 'auto' }],
+        'eslint.validate': ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'markdown'],
+        'prettier.useEditorConfig': true,
+      };
+
+      const existingSettings = (yield* readJsonIfExists<Record<string, unknown>>(settingsPath)) ?? {};
+      const nextSettings = { ...existingSettings, ...desiredSettings };
+
+      // Sort keys for stability
+      const sortedSettings = Object.keys(nextSettings)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, key) => {
+          acc[key] = (nextSettings as Record<string, unknown>)[key];
+          return acc;
+        }, {});
+
+      yield* writeJson(settingsPath, sortedSettings);
+      yield* Effect.logInfo(`✅ Updated ${settingsPath}`);
+
+      // Extension recommendations
+      type ExtensionsJson = { recommendations?: Array<string>; unwantedRecommendations?: Array<string> };
+      const existingExtensions = (yield* readJsonIfExists<ExtensionsJson>(extensionsPath)) ?? {};
+
+      const recommendations = new Set<string>(existingExtensions.recommendations ?? []);
+      recommendations.add('esbenp.prettier-vscode');
+      recommendations.add('dbaeumer.vscode-eslint');
+
+      const nextExtensions: ExtensionsJson = {
+        ...existingExtensions,
+        recommendations: Array.from(recommendations).sort(),
+      };
+
+      yield* writeJson(extensionsPath, nextExtensions);
+      yield* Effect.logInfo(`✅ Updated ${extensionsPath}`);
+
+      yield* Effect.logInfo('🎉 VS Code setup complete!');
+    });
+
+    return { setup };
+  }),
+  dependencies: [Path.layer, PackageManagerService.Default],
+}) {}
+


### PR DESCRIPTION
Add a new CLI stage to configure VS Code settings and extension recommendations for optimal ESLint and Prettier integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-2dc5e6bd-e856-4f27-8e90-f6004d57bba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2dc5e6bd-e856-4f27-8e90-f6004d57bba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

