### PR TITLE
Setup and test @2digits/cli package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,8 @@
     "bin": "tsx ./src/bin.ts",
     "build": "tsdown --minify --config-loader unconfig",
     "dev": "tsdown --watch --config-loader unconfig",
-    "types": "tsc --noEmit"
+    "types": "tsc --noEmit",
+    "test": "vitest --run"
   },
   "license": "MIT",
   "dependencies": {
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
     "@effect/language-service": "catalog:",
+    "vitest": "catalog:",
     "tsdown": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// Node environment for CLI testing
+		environment: 'node',
+		globals: true,
+		coverage: {
+			reporter: ['text', 'json', 'html'],
+		},
+	},
+});
+


### PR DESCRIPTION
Set up Vitest for `@2digits/cli` to introduce a testing framework for the package.

---
<a href="https://cursor.com/background-agent?bcId=bc-72afface-43ad-43c5-8bd4-86104c054e00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-72afface-43ad-43c5-8bd4-86104c054e00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

