### PR TITLE
🔧 Disable digest pinning for peer dependencies in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,11 @@
   "extends": ["local>2digits-agency/configs//packages/renovate/default"],
   "rebaseWhen": "auto",
   "schedule": ["at any time"],
-  "updateNotScheduled": true
+  "updateNotScheduled": true,
+  "packageRules": [
+    {
+      "matchDepTypes": ["peerDependencies"],
+      "pinDigests": false
+    }
+  ]
 }


### PR DESCRIPTION
Adds a new rule to Renovate configuration to prevent pinning digests for peer dependencies. This ensures that peer dependencies remain flexible and compatible with various versions, rather than being locked to specific commits.