### PR TITLE
🔧 Update renovate config to group more packages

### DIFF
--- a/.changeset/eighty-ducks-rescue.md
+++ b/.changeset/eighty-ducks-rescue.md
@@ -1,0 +1,5 @@
+---
+'@2digits/renovate-config': patch
+---
+
+Updated renovate config to group more packages

--- a/packages/renovate/src/default.json
+++ b/packages/renovate/src/default.json
@@ -16,15 +16,18 @@
   "updateNotScheduled": false,
   "packageRules": [
     { "groupName": "2DIGITS Configs", "matchPackageNames": ["/^@2digits/"] },
+    { "groupName": "Better Auth", "matchPackageNames": ["better-auth", "/^@better-auth//"] },
     { "groupName": "Hey API", "matchPackageNames": ["/^@hey-api//"] },
     { "groupName": "Notificare", "matchPackageNames": ["/^react-native-notificare/"] },
     { "groupName": "Orval", "matchPackageNames": ["orval", "/^@orval/"] },
-    { "groupName": "Unified & Rehype", "matchPackageNames": ["unified", "/^rehype-/"] },
-    { "groupName": "nativewind", "matchPackageNames": ["nativewind", "react-native-css-interop"] },
-    { "groupName": "react-native-bottom-tabs", "matchPackageNames": ["react-native-bottom-tabs", "/^@bottom-tabs//"] },
-    { "groupName": "react-native-firebase", "matchPackageNames": ["/^@react-native-firebase//"] },
+    { "groupName": "Payload", "matchPackageNames": ["payload", "/^@payloadcms//"] },
     { "groupName": "PostHog", "matchPackageNames": ["/^posthog-/"] },
-    { "groupName": "Better Auth", "matchPackageNames": ["better-auth", "/^@better-auth//"] }
+    { "groupName": "React Email", "matchPackageNames": ["react-email", "/^@react-email//"] },
+    { "groupName": "Unified & Rehype", "matchPackageNames": ["unified", "/^rehype-/"] },
+    { "groupName": "nativewind", "matchPackageNames": ["nativewind", "react-native-css-interop", "react-native-css"] },
+    { "groupName": "oRPC", "matchPackageNames": ["/^@orpc//"] },
+    { "groupName": "react-native-bottom-tabs", "matchPackageNames": ["react-native-bottom-tabs", "/^@bottom-tabs//"] },
+    { "groupName": "react-native-firebase", "matchPackageNames": ["/^@react-native-firebase//"] }
   ],
   "pruneStaleBranches": true,
   "ignorePrAuthor": false,


### PR DESCRIPTION
# Enhanced Renovate Configuration with Additional Package Groups

This PR updates the renovate configuration to group more related packages together for more efficient dependency management. The following new package groups have been added:

- Payload (payload, @payloadcms/*)
- React Email (react-email, @react-email/*)
- oRPC (@orpc/*)

Additionally, the "nativewind" group has been expanded to include "react-native-css" alongside the existing packages.

The package groups have also been reordered alphabetically for better readability.