### PR TITLE
🔄 Convert to namespaced imports for effect packages

### DIFF
--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -1,5 +1,8 @@
-import { Command, Options } from '@effect/cli';
-import { Console, Effect, Option } from 'effect';
+import * as Command from '@effect/cli/Command';
+import * as Options from '@effect/cli/Options';
+import * as Console from 'effect/Console';
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 
 import { moduleVersion } from './internal/version';
 import { PrettierSetupService } from './services/PrettierSetupService';

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
-import { CliConfig } from '@effect/cli';
-import { NodeContext, NodeRuntime } from '@effect/platform-node';
-import { Effect, Layer } from 'effect';
+import * as CliConfig from '@effect/cli/CliConfig';
+import * as NodeContext from '@effect/platform-node/NodeContext';
+import * as NodeRuntime from '@effect/platform-node/NodeRuntime';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
 
 import { cli } from './Cli';
 import { PrettierSetupService } from './services/PrettierSetupService';

--- a/packages/cli/src/services/PackageManagerService.ts
+++ b/packages/cli/src/services/PackageManagerService.ts
@@ -1,6 +1,11 @@
 /* eslint-disable unicorn/no-array-callback-reference */
-import { Command, Path } from '@effect/platform';
-import { Array, Data, Effect, Stream, String } from 'effect';
+import * as Command from '@effect/platform/Command';
+import * as Path from '@effect/platform/Path';
+import * as Array from 'effect/Array';
+import * as Data from 'effect/Data';
+import * as Effect from 'effect/Effect';
+import * as Stream from 'effect/Stream';
+import * as String from 'effect/String';
 import * as nypm from 'nypm';
 import * as pkgTypes from 'pkg-types';
 

--- a/packages/cli/src/services/PrettierSetupService.ts
+++ b/packages/cli/src/services/PrettierSetupService.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect';
+import * as Effect from 'effect/Effect';
 
 import { PackageManagerService } from './PackageManagerService';
 

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "@2digits/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "plugins": [{ "name": "@effect/language-service" }]
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "namespaceImportPackages": ["effect", "@effect/*"]
+      }
+    ]
   },
   "include": ["**/*.ts"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
Updated imports to use granular imports from Effect libraries instead of namespace imports. This change improves tree-shaking capabilities and reduces bundle size by only importing the specific modules needed. Also configured the Effect language service plugin to properly handle namespace imports for better developer experience.