### PR TITLE
🔧 Ignore .context directory in Knip configuration

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -5,5 +5,6 @@
       "ignore": ["fixtures/**", "_fixtures/**"],
       "ignoreDependencies": ["react", "@types/react"]
     }
-  }
+  },
+  "ignore": [".context/**"]
 }


### PR DESCRIPTION
Ignore `.context/**` directory in KNIP configuration to prevent it from being analyzed for unused code.