### PR TITLE
✅ Add tests for CLI package and implement CurrentWorkingDirService

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -4,6 +4,9 @@
     "packages/eslint-config": {
       "ignore": ["fixtures/**", "_fixtures/**"],
       "ignoreDependencies": ["react", "@types/react"]
+    },
+    "packages/cli": {
+      "ignore": ["test/fixtures/**"]
     }
   },
   "ignore": [".context/**"]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,8 @@
     "bin": "tsx ./src/bin.ts",
     "build": "tsdown --minify --config-loader unconfig",
     "dev": "tsdown --watch --config-loader unconfig",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "types": "tsc --noEmit"
   },
   "license": "MIT",
@@ -40,9 +42,11 @@
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
     "@effect/language-service": "catalog:",
+    "@effect/vitest": "catalog:",
     "tsdown": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "unplugin-replace": "catalog:"
+    "unplugin-replace": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -6,6 +6,7 @@ import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 
 import { cli } from './Cli';
+import { CurrentWorkingDirService } from './services/CurrentWorkingDirService';
 import { EslintDetectionService } from './services/EslintDetectionService';
 import { EslintSetupService } from './services/EslintSetupService';
 import { PrettierSetupService } from './services/PrettierSetupService';
@@ -13,6 +14,7 @@ import { ProjectDetectionService } from './services/ProjectDetectionService';
 
 const MainLive = Layer.mergeAll(
   CliConfig.layer(),
+  CurrentWorkingDirService.Default,
   PrettierSetupService.Default,
   EslintSetupService.Default,
   ProjectDetectionService.Default,

--- a/packages/cli/src/services/CurrentWorkingDirService.ts
+++ b/packages/cli/src/services/CurrentWorkingDirService.ts
@@ -1,0 +1,8 @@
+import * as Effect from 'effect/Effect';
+
+export class CurrentWorkingDirService extends Effect.Service<CurrentWorkingDirService>()('CurrentWorkingDirService', {
+  succeed: {
+    cwd: Effect.sync(() => process.cwd()),
+  },
+  accessors: true,
+}) {}

--- a/packages/cli/test/fixtures/existing-configs/.prettierrc.json
+++ b/packages/cli/test/fixtures/existing-configs/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/cli/test/fixtures/existing-configs/eslint.config.js
+++ b/packages/cli/test/fixtures/existing-configs/eslint.config.js
@@ -1,0 +1,3 @@
+import config from "@company/eslint-config"
+
+export default config

--- a/packages/cli/test/fixtures/existing-configs/package.json
+++ b/packages/cli/test/fixtures/existing-configs/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-existing-configs",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "lint": "eslint .",
+    "format": "prettier --check ."
+  },
+  "devDependencies": {
+    "eslint": "^9.0.0",
+    "prettier": "^3.0.0",
+    "@company/eslint-config": "^1.0.0"
+  },
+  "prettier": "@company/prettier-config",
+  "packageManager": "pnpm@9.0.0"
+}

--- a/packages/cli/test/fixtures/monorepo-turborepo/package.json
+++ b/packages/cli/test/fixtures/monorepo-turborepo/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "turbo run build"
+  },
+  "devDependencies": {
+    "turbo": "^2.0.0"
+  },
+  "packageManager": "pnpm@9.0.0"
+}

--- a/packages/cli/test/fixtures/monorepo-turborepo/packages/app/package.json
+++ b/packages/cli/test/fixtures/monorepo-turborepo/packages/app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/app",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/packages/cli/test/fixtures/monorepo-turborepo/pnpm-workspace.yaml
+++ b/packages/cli/test/fixtures/monorepo-turborepo/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/packages/cli/test/fixtures/monorepo-turborepo/turbo.json
+++ b/packages/cli/test/fixtures/monorepo-turborepo/turbo.json
@@ -1,0 +1,11 @@
+{
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^test"]
+    }
+  }
+}

--- a/packages/cli/test/fixtures/single-package/package.json
+++ b/packages/cli/test/fixtures/single-package/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-single-package",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest"
+  },
+  "devDependencies": {},
+  "packageManager": "pnpm@9.0.0"
+}

--- a/packages/cli/test/helpers/MockCommandService.ts
+++ b/packages/cli/test/helpers/MockCommandService.ts
@@ -1,0 +1,130 @@
+import type * as Command from '@effect/platform/Command';
+import * as CommandExecutor from '@effect/platform/CommandExecutor';
+import * as Array from 'effect/Array';
+import * as Effect from 'effect/Effect';
+import * as Inspectable from 'effect/Inspectable';
+import * as Layer from 'effect/Layer';
+import * as Ref from 'effect/Ref';
+import * as Sink from 'effect/Sink';
+import * as Stream from 'effect/Stream';
+
+/**
+ * Represents a command that was executed during a test
+ */
+interface ExecutedCommand {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly shell: boolean | string;
+}
+
+/**
+ * A spy/intercept implementation of CommandExecutor for testing.
+ * Records all commands that would be executed and returns fake successful results.
+ */
+export class MockCommandExecutor extends Effect.Service<MockCommandExecutor>()('MockCommandExecutor', {
+  effect: Effect.gen(function* () {
+    const executed = yield* Ref.make<Array<ExecutedCommand>>([]);
+
+    const recordCommand = (command: Command.Command): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (command._tag === 'StandardCommand') {
+          yield* Ref.update(executed, (cmds) =>
+            Array.append(cmds, {
+              command: command.command,
+              args: command.args,
+              shell: command.shell,
+            }),
+          );
+        }
+      });
+
+    const createMockProcess = (_command: Command.Command): CommandExecutor.Process => ({
+      [CommandExecutor.ProcessTypeId]: CommandExecutor.ProcessTypeId,
+      pid: 12_345 as CommandExecutor.ProcessId,
+      exitCode: Effect.succeed(0 as CommandExecutor.ExitCode),
+      isRunning: Effect.succeed(false),
+      kill: () => Effect.void,
+      stderr: Stream.empty,
+      stdin: Sink.drain,
+      stdout: Stream.empty,
+      [Symbol.for('nodejs.util.inspect.custom')]() {
+        return 'MockProcess';
+      },
+      toJSON() {
+        return { _tag: 'MockProcess', pid: 12_345 };
+      },
+      [Inspectable.NodeInspectSymbol](): unknown {
+        throw new Error('Function not implemented.');
+      },
+    });
+
+    const executor: CommandExecutor.CommandExecutor = {
+      [CommandExecutor.TypeId]: CommandExecutor.TypeId,
+      exitCode: (command) =>
+        Effect.gen(function* () {
+          yield* recordCommand(command);
+
+          return 0 as CommandExecutor.ExitCode;
+        }),
+      start: (command) =>
+        Effect.gen(function* () {
+          yield* recordCommand(command);
+
+          return createMockProcess(command);
+        }),
+      string: (command, _encoding) =>
+        Effect.gen(function* () {
+          yield* recordCommand(command);
+
+          return '';
+        }),
+      lines: (command, _encoding) =>
+        Effect.gen(function* () {
+          yield* recordCommand(command);
+
+          return [];
+        }),
+      stream: (command) => {
+        return Stream.fromEffect(recordCommand(command)).pipe(Stream.flatMap(() => Stream.empty));
+      },
+      streamLines: (command, _encoding) => {
+        return Stream.fromEffect(recordCommand(command)).pipe(Stream.flatMap(() => Stream.empty));
+      },
+    };
+
+    return {
+      executor,
+      /**
+       * Get all commands that were executed
+       */
+      getExecuted: Ref.get(executed),
+      /**
+       * Clear the list of executed commands
+       */
+      clear: Ref.set(executed, []),
+    } as const;
+  }),
+  dependencies: [],
+}) {}
+
+/**
+ * Layer that provides the mock CommandExecutor
+ */
+export const MockCommandExecutorLayer = Layer.effect(
+  CommandExecutor.CommandExecutor,
+  Effect.gen(function* () {
+    const mock = yield* MockCommandExecutor;
+
+    return mock.executor;
+  }),
+).pipe(Layer.provide(MockCommandExecutor.Default));
+
+/**
+ * Helper to get the executed commands in tests
+ */
+export const getExecutedCommands = MockCommandExecutor.pipe(Effect.flatMap((mock) => mock.getExecuted));
+
+/**
+ * Helper to clear executed commands in tests
+ */
+export const clearExecutedCommands = MockCommandExecutor.pipe(Effect.flatMap((mock) => mock.clear));

--- a/packages/cli/test/helpers/testEnv.ts
+++ b/packages/cli/test/helpers/testEnv.ts
@@ -1,0 +1,67 @@
+import * as FileSystem from '@effect/platform/FileSystem';
+import * as Path from '@effect/platform/Path';
+import * as Url from '@effect/platform/Url';
+import * as Effect from 'effect/Effect';
+import * as Either from 'effect/Either';
+
+/**
+ * Creates a scoped temp directory and switches cwd to it.
+ * Automatically cleans up temp dir and restores cwd when scope ends.
+ *
+ * @param prefix - Prefix for temp directory name
+ * @returns Effect that yields the temp directory path
+ */
+export const withTempTestEnv = Effect.fn('withTempTestEnv')(function* (prefix: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: `test-${prefix}-` });
+
+  // Change to temp directory within the same scope
+  yield* Effect.acquireRelease(
+    Effect.sync(() => {
+      const originalCwd = process.cwd();
+
+      process.chdir(tempDir);
+
+      return originalCwd;
+    }),
+    (originalCwd) => Effect.sync(() => process.chdir(originalCwd)),
+  );
+
+  return tempDir;
+});
+
+export const fixturesBasePath = Effect.gen(function* () {
+  const path = yield* Path.Path;
+
+  const __filename = yield* path.fromFileUrl(Either.getOrThrow(Url.fromString(import.meta.url)));
+  const __dirname = path.dirname(__filename);
+
+  return path.join(__dirname, '../fixtures/');
+});
+
+type Fixture = 'existing-configs' | 'monorepo-turborepo' | 'single-package';
+
+/**
+ * Copies a fixture directory into the current working directory (temp dir).
+ * Should be called after withTempTestEnv.
+ *
+ * @param fixtureName - Name of fixture directory in test/fixtures/
+ * @returns Effect with void
+ */
+export const copyFixture = Effect.fn('copyFixture')(function* (fixtureName: Fixture) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const fixturesBaseDir = yield* fixturesBasePath;
+  const fixtureDir = path.join(fixturesBaseDir, fixtureName);
+
+  const fixtureDirExists = yield* fs.exists(fixtureDir);
+
+  if (!fixtureDirExists) {
+    return yield* Effect.fail(new Error(`Fixture not found: ${fixtureName} at ${fixtureDir}`));
+  }
+
+  const targetDir = process.cwd();
+
+  yield* fs.copy(`${fixtureDir}/`, targetDir);
+});

--- a/packages/cli/test/unit/services/EslintDetectionService.test.ts
+++ b/packages/cli/test/unit/services/EslintDetectionService.test.ts
@@ -1,0 +1,133 @@
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import * as NodePath from '@effect/platform-node/NodePath';
+import * as Path from '@effect/platform/Path';
+import { describe, it } from '@effect/vitest';
+import { assertTrue, strictEqual } from '@effect/vitest/utils';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+
+import { EslintDetectionService } from '../../../src/services/EslintDetectionService.js';
+import { PackageManagerService } from '../../../src/services/PackageManagerService.js';
+import { MockCommandExecutor, MockCommandExecutorLayer } from '../../helpers/MockCommandService.js';
+import { copyFixture, fixturesBasePath, withTempTestEnv } from '../../helpers/testEnv.js';
+
+describe('EslintDetectionService', () => {
+  const testLayer = Layer.mergeAll(
+    EslintDetectionService.Default,
+    PackageManagerService.Default,
+    MockCommandExecutor.Default,
+    MockCommandExecutorLayer,
+    NodeFileSystem.layer,
+    NodePath.layer,
+  );
+
+  describe('isEslintInstalled', () => {
+    it.scoped('detects eslint in devDependencies', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('existing-configs');
+
+        const service = yield* EslintDetectionService;
+        const result = yield* service.isEslintInstalled();
+
+        strictEqual(result, true);
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('returns false when eslint not installed', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+
+        const service = yield* EslintDetectionService;
+        const result = yield* service.isEslintInstalled();
+
+        strictEqual(result, false);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('hasEslintConfig', () => {
+    it.scoped('detects existing eslint config file', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('existing-configs');
+
+        const service = yield* EslintDetectionService;
+        const result = yield* service.hasEslintConfig();
+
+        strictEqual(result, true);
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('returns false when no config exists', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+
+        const service = yield* EslintDetectionService;
+        const result = yield* service.hasEslintConfig();
+
+        strictEqual(result, false);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('detectExistingConfigs', () => {
+    it.scoped('returns list of existing config files', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('existing-configs');
+
+        const service = yield* EslintDetectionService;
+        const configs = yield* service.detectExistingConfigs();
+
+        assertTrue(configs.length > 0);
+        assertTrue(configs.some((path) => path.includes('eslint.config.js')));
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('returns empty array when no configs exist', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+
+        const service = yield* EslintDetectionService;
+        const configs = yield* service.detectExistingConfigs();
+
+        strictEqual(configs.length, 0);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('uses2DigitsConfig', () => {
+    it.effect('detects @2digits/eslint-config in config file', () =>
+      Effect.gen(function* () {
+        const service = yield* EslintDetectionService;
+        const path = yield* Path.Path;
+        const fixturesDir = yield* fixturesBasePath;
+
+        // For this test, we need to create a fixture with @2digits/eslint-config
+        // Let's test with a specific path
+        const configPath = path.join(fixturesDir, 'existing-configs/eslint.config.js');
+
+        const result = yield* service.uses2DigitsConfig(configPath);
+        // The fixture has @company/eslint-config, not @2digits
+
+        strictEqual(result, false);
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('returns false when config file does not exist', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+
+        const service = yield* EslintDetectionService;
+        const result = yield* service.uses2DigitsConfig();
+
+        strictEqual(result, false);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+});

--- a/packages/cli/test/unit/services/EslintSetupService.test.ts
+++ b/packages/cli/test/unit/services/EslintSetupService.test.ts
@@ -1,0 +1,127 @@
+/* eslint-disable sonar/no-duplicate-string */
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import * as NodePath from '@effect/platform-node/NodePath';
+import * as FileSystem from '@effect/platform/FileSystem';
+import * as Path from '@effect/platform/Path';
+import { describe, expect, it } from '@effect/vitest';
+import { assertTrue, strictEqual } from '@effect/vitest/utils';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+
+import { EslintDetectionService } from '../../../src/services/EslintDetectionService.js';
+import { EslintSetupService } from '../../../src/services/EslintSetupService.js';
+import { PackageManagerService } from '../../../src/services/PackageManagerService.js';
+import { ProjectDetectionService } from '../../../src/services/ProjectDetectionService.js';
+import { MockCommandExecutor, MockCommandExecutorLayer } from '../../helpers/MockCommandService.js';
+import { copyFixture, withTempTestEnv } from '../../helpers/testEnv.js';
+
+describe('EslintSetupService', () => {
+  const testLayer = Layer.mergeAll(
+    EslintSetupService.Default,
+    EslintDetectionService.Default,
+    ProjectDetectionService.Default,
+    PackageManagerService.Default,
+    MockCommandExecutor.Default,
+    MockCommandExecutorLayer,
+    NodeFileSystem.layer,
+    NodePath.layer,
+  );
+
+  describe('setup - single package', () => {
+    it.scoped('sets up eslint in single package project', (ctx) =>
+      Effect.gen(function* () {
+        const service = yield* EslintSetupService;
+        const pm = yield* PackageManagerService;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        const tempDir = yield* withTempTestEnv(ctx.task.id);
+
+        yield* copyFixture('single-package');
+
+        // Run setup
+        yield* service.setup();
+
+        // Check eslint.config.ts was created
+        const configPath = path.join(tempDir, 'eslint.config.ts');
+        const configExists = yield* fs.exists(configPath);
+
+        strictEqual(configExists, true);
+
+        // Check config content
+        const configContent = yield* fs.readFileString(configPath);
+
+        assertTrue(configContent.includes('@2digits/eslint-config'));
+        assertTrue(configContent.includes('export default twoDigits()'));
+
+        // Check package.json was updated
+        const updatedPkg = yield* pm.readPackageJson({ id: tempDir });
+
+        assertTrue(updatedPkg.scripts?.lint !== undefined);
+        assertTrue(updatedPkg.scripts['lint:fix'] !== undefined);
+        strictEqual(updatedPkg.scripts.lint, 'eslint .');
+        strictEqual(updatedPkg.scripts['lint:fix'], 'eslint . --fix');
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('setup - monorepo', () => {
+    it.scoped('sets up eslint in monorepo project', (ctx) =>
+      Effect.gen(function* () {
+        const service = yield* EslintSetupService;
+        const pm = yield* PackageManagerService;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        const tempDir = yield* withTempTestEnv(ctx.task.id);
+
+        yield* copyFixture('monorepo-turborepo');
+
+        yield* service.setup();
+
+        const rootConfigContent = yield* fs.readFileString(path.join(tempDir, 'eslint.config.ts'));
+
+        expect(rootConfigContent).toMatchSnapshot('eslint.config.ts');
+
+        const workspaceConfigContent = yield* fs.readFileString(path.join(tempDir, 'packages/app/eslint.config.ts'));
+
+        expect(workspaceConfigContent).toMatchSnapshot('packages/app/eslint.config.ts');
+
+        const updatedPkg = yield* pm.readPackageJson({ id: tempDir });
+
+        expect(updatedPkg).toMatchSnapshot('package.json');
+
+        const turboContent = yield* fs.readFileString(path.join(tempDir, 'turbo.json'));
+
+        expect(JSON.parse(turboContent)).toMatchSnapshot('turbo.json');
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('setup - with existing config', () => {
+    it.scoped('backs up existing eslint config', (ctx) =>
+      Effect.gen(function* () {
+        const service = yield* EslintSetupService;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        const tempDir = yield* withTempTestEnv(ctx.task.id);
+
+        yield* copyFixture('existing-configs');
+
+        // Run setup
+        yield* service.setup();
+
+        const backupPath = path.join(tempDir, 'eslint.config.js.backup');
+        const backupContent = yield* fs.readFileString(backupPath);
+
+        expect(backupContent).toMatchSnapshot('eslint.config.js.backup');
+
+        const newConfigPath = path.join(tempDir, 'eslint.config.ts');
+        const newConfigContent = yield* fs.readFileString(newConfigPath);
+
+        expect(newConfigContent).toMatchSnapshot('eslint.config.ts');
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+});

--- a/packages/cli/test/unit/services/PackageManagerService.test.ts
+++ b/packages/cli/test/unit/services/PackageManagerService.test.ts
@@ -1,0 +1,166 @@
+/* eslint-disable sonar/no-duplicate-string */
+
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import * as NodePath from '@effect/platform-node/NodePath';
+import { describe, expect, it } from '@effect/vitest';
+import { assertTrue, strictEqual } from '@effect/vitest/utils';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+
+import { PackageManagerService } from '../../../src/services/PackageManagerService.js';
+import {
+  clearExecutedCommands,
+  getExecutedCommands,
+  MockCommandExecutor,
+  MockCommandExecutorLayer,
+} from '../../helpers/MockCommandService.js';
+import { copyFixture, withTempTestEnv } from '../../helpers/testEnv.js';
+
+describe('PackageManagerService', () => {
+  const testLayer = Layer.mergeAll(
+    PackageManagerService.Default,
+    MockCommandExecutor.Default,
+    MockCommandExecutorLayer,
+    NodeFileSystem.layer,
+    NodePath.layer,
+  );
+
+  describe('resolveRoot', () => {
+    it.scoped('resolves workspace root', (ctx) =>
+      Effect.gen(function* () {
+        const dir = yield* withTempTestEnv(ctx.task.id);
+
+        yield* copyFixture('monorepo-turborepo');
+
+        const service = yield* PackageManagerService;
+        const root = yield* service.resolveRoot();
+
+        assertTrue(root.includes(dir));
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('readPackageJson', () => {
+    it.scoped('reads package.json from current directory', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+
+        const service = yield* PackageManagerService;
+        const pkg = yield* service.readPackageJson();
+
+        expect(pkg).toMatchObject({
+          name: 'test-single-package',
+          version: '1.0.0',
+        });
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('reads package.json from specified directory', (ctx) =>
+      Effect.gen(function* () {
+        const tempDir = yield* withTempTestEnv(ctx.task.id);
+
+        yield* copyFixture('monorepo-turborepo');
+
+        const service = yield* PackageManagerService;
+
+        const pkg = yield* service.readPackageJson({
+          id: tempDir,
+        });
+
+        expect(pkg).toMatchObject({
+          name: 'test-monorepo',
+          private: true,
+        });
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('getPackageManager', () => {
+    it.scoped('detects pnpm package manager', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+
+        const service = yield* PackageManagerService;
+        const pm = yield* service.getPackageManager();
+
+        strictEqual(pm.name, 'pnpm');
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('addDependencies', () => {
+    it.scoped('executes command to add dev dependencies', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+        yield* clearExecutedCommands;
+
+        const service = yield* PackageManagerService;
+
+        yield* service.addDependencies({
+          devDependencies: ['prettier', '@2digits/prettier-config'],
+        });
+
+        const executed = yield* getExecutedCommands;
+
+        assertTrue(executed.length > 0);
+
+        // Should have executed a pnpm add command
+        const addCommand = executed.find((cmd) => cmd.command.includes('add') || cmd.shell === true);
+
+        assertTrue(addCommand !== undefined);
+
+        expect(executed.at(0)?.command).toMatchInlineSnapshot(
+          `"pnpm add --workspace-root -D prettier @2digits/prettier-config"`,
+        );
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('executes separate commands for dependencies and devDependencies', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+        yield* clearExecutedCommands;
+
+        const service = yield* PackageManagerService;
+
+        yield* service.addDependencies({
+          dependencies: ['effect'],
+          devDependencies: ['vitest'],
+        });
+
+        const executed = yield* getExecutedCommands;
+
+        // Should execute 2 commands (one for deps, one for devDeps)
+        assertTrue(executed.length >= 2);
+
+        expect(executed.map((e) => e.command)).toMatchInlineSnapshot(`
+          [
+            "pnpm add --workspace-root -D vitest",
+            "pnpm add --workspace-root effect",
+          ]
+        `);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('runScriptCommand', () => {
+    it.scoped('returns command string for running script', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+
+        const service = yield* PackageManagerService;
+        const cmd = yield* service.runScriptCommand({ script: 'test' });
+
+        // Should return a pnpm command
+        assertTrue(cmd.includes('pnpm'));
+        assertTrue(cmd.includes('test'));
+
+        expect(cmd).toMatchInlineSnapshot(`"pnpm run test"`);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+});

--- a/packages/cli/test/unit/services/PrettierSetupService.test.ts
+++ b/packages/cli/test/unit/services/PrettierSetupService.test.ts
@@ -1,0 +1,136 @@
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import * as NodePath from '@effect/platform-node/NodePath';
+import { describe, expect, it } from '@effect/vitest';
+import { assertTrue, strictEqual } from '@effect/vitest/utils';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+
+import { PackageManagerService } from '../../../src/services/PackageManagerService.js';
+import { PrettierSetupService } from '../../../src/services/PrettierSetupService.js';
+import {
+  clearExecutedCommands,
+  getExecutedCommands,
+  MockCommandExecutor,
+  MockCommandExecutorLayer,
+} from '../../helpers/MockCommandService.js';
+import { copyFixture, withTempTestEnv } from '../../helpers/testEnv.js';
+
+describe('PrettierSetupService', () => {
+  const testLayer = Layer.mergeAll(
+    PrettierSetupService.Default,
+    PackageManagerService.Default,
+    MockCommandExecutor.Default,
+    MockCommandExecutorLayer,
+    NodeFileSystem.layer,
+    NodePath.layer,
+  );
+
+  describe('setup', () => {
+    it.scoped('adds prettier config and scripts to package.json', (ctx) =>
+      Effect.gen(function* () {
+        const service = yield* PrettierSetupService;
+        const pm = yield* PackageManagerService;
+
+        const tempDir = yield* withTempTestEnv(ctx.task.id);
+
+        yield* copyFixture('single-package');
+
+        yield* clearExecutedCommands;
+
+        // Run setup
+        yield* service.setup();
+
+        // Read updated package.json
+        const updatedPkg = yield* pm.readPackageJson({ id: tempDir });
+
+        // Check prettier config was added
+        strictEqual(updatedPkg.prettier, '@2digits/prettier-config');
+
+        expect(updatedPkg.scripts).toMatchObject({
+          format: 'prettier . --ignore-unknown --check --cache',
+          'format:fix': 'prettier . --ignore-unknown --write --cache',
+        });
+
+        // Check that addDependencies was called
+        const executed = yield* getExecutedCommands;
+
+        assertTrue(executed.length > 0);
+
+        expect(executed.at(0)?.command).toMatchInlineSnapshot(
+          `"pnpm add --workspace-root -D prettier @2digits/prettier-config"`,
+        );
+
+        expect(updatedPkg).toMatchSnapshot();
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('preserves existing prettier config', (ctx) =>
+      Effect.gen(function* () {
+        const service = yield* PrettierSetupService;
+        const pm = yield* PackageManagerService;
+
+        const tempDir = yield* withTempTestEnv(ctx.task.id);
+
+        yield* copyFixture('existing-configs');
+
+        yield* clearExecutedCommands;
+
+        // Run setup
+        yield* service.setup();
+
+        // Read updated package.json
+        const updatedPkg = yield* pm.readPackageJson({ id: tempDir });
+
+        // Should preserve custom config
+        strictEqual(updatedPkg.prettier, '@company/prettier-config');
+
+        expect(updatedPkg.scripts).toMatchObject({
+          'format:fix': 'prettier . --ignore-unknown --write --cache',
+        });
+
+        expect(updatedPkg.scripts).not.toMatchObject({
+          format: 'prettier . --ignore-unknown --check --cache',
+        });
+
+        expect(updatedPkg).toMatchSnapshot();
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('preserves existing scripts', (ctx) =>
+      Effect.gen(function* () {
+        const service = yield* PrettierSetupService;
+        const pm = yield* PackageManagerService;
+
+        const tempDir = yield* withTempTestEnv(ctx.task.id);
+
+        yield* copyFixture('single-package');
+
+        const pkg = yield* pm.readPackageJson({ id: tempDir });
+
+        pkg.scripts = { ...pkg.scripts };
+        pkg.scripts.format = 'custom-format-command';
+
+        yield* pm.writePackageJson({ id: tempDir, content: pkg });
+
+        yield* clearExecutedCommands;
+
+        // Run setup
+        yield* service.setup();
+
+        // Read updated package.json
+        const updatedPkg = yield* pm.readPackageJson({ id: tempDir });
+
+        // Should preserve existing format script
+        strictEqual(updatedPkg.scripts?.format, 'custom-format-command');
+
+        // Should preserve test script
+        strictEqual(updatedPkg.scripts?.test, 'vitest');
+
+        // Should still add format:fix if not present
+        assertTrue(updatedPkg.scripts?.['format:fix'] !== undefined);
+
+        expect(updatedPkg).toMatchSnapshot();
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+});

--- a/packages/cli/test/unit/services/ProjectDetectionService.test.ts
+++ b/packages/cli/test/unit/services/ProjectDetectionService.test.ts
@@ -1,0 +1,110 @@
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import * as NodePath from '@effect/platform-node/NodePath';
+import * as Path from '@effect/platform/Path';
+import { describe, expect, it } from '@effect/vitest';
+import { deepStrictEqual, strictEqual } from '@effect/vitest/utils';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+
+import { PackageManagerService } from '../../../src/services/PackageManagerService.js';
+import { ProjectDetectionService } from '../../../src/services/ProjectDetectionService.js';
+import { MockCommandExecutor, MockCommandExecutorLayer } from '../../helpers/MockCommandService.js';
+import { copyFixture, withTempTestEnv } from '../../helpers/testEnv.js';
+
+describe('ProjectDetectionService', () => {
+  const testLayer = Layer.mergeAll(
+    ProjectDetectionService.Default,
+    PackageManagerService.Default,
+    MockCommandExecutor.Default,
+    MockCommandExecutorLayer,
+    NodeFileSystem.layer,
+    NodePath.layer,
+  );
+
+  describe('isMonorepo', () => {
+    it.scoped('detects monorepo with turbo.json', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('monorepo-turborepo');
+
+        const service = yield* ProjectDetectionService;
+        const result = yield* service.isMonorepo();
+
+        strictEqual(result, true);
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('does not detect monorepo without turbo.json', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+
+        const service = yield* ProjectDetectionService;
+        const result = yield* service.isMonorepo();
+
+        strictEqual(result, false);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('isTurborepoProject', () => {
+    it.scoped('is an alias for isMonorepo', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('monorepo-turborepo');
+
+        const service = yield* ProjectDetectionService;
+        const result = yield* service.isTurborepoProject();
+
+        strictEqual(result, true);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('discoverWorkspaces', () => {
+    it.scoped('discovers workspaces in packages/ directory', (ctx) =>
+      Effect.gen(function* () {
+        const testDir = yield* withTempTestEnv(ctx.task.id);
+
+        yield* copyFixture('monorepo-turborepo');
+
+        const service = yield* ProjectDetectionService;
+        const workspaces = yield* service.discoverWorkspaces();
+
+        // Should find the packages/app workspace
+        strictEqual(workspaces.length, 1);
+        strictEqual(workspaces[0]?.includes('packages/app'), true);
+
+        expect(workspaces.at(0)).toMatch(`${testDir}/packages/app`);
+      }).pipe(Effect.provide(testLayer)),
+    );
+
+    it.scoped('returns empty array for single package project', (ctx) =>
+      Effect.gen(function* () {
+        yield* withTempTestEnv(ctx.task.id);
+        yield* copyFixture('single-package');
+
+        const service = yield* ProjectDetectionService;
+        const workspaces = yield* service.discoverWorkspaces();
+
+        deepStrictEqual(workspaces, []);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+
+  describe('getWorkspacePackageJsonPath', () => {
+    it.effect('returns correct package.json path', () =>
+      Effect.gen(function* () {
+        const service = yield* ProjectDetectionService;
+        const path = yield* Path.Path;
+
+        const workspacePath = '/root/packages/app';
+        const result = service.getWorkspacePackageJsonPath(workspacePath);
+
+        const expected = path.join(workspacePath, 'package.json');
+
+        strictEqual(result, expected);
+      }).pipe(Effect.provide(testLayer)),
+    );
+  });
+});

--- a/packages/cli/test/unit/services/__snapshots__/EslintSetupService.test.ts.snap
+++ b/packages/cli/test/unit/services/__snapshots__/EslintSetupService.test.ts.snap
@@ -1,0 +1,85 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EslintSetupService > setup - monorepo > sets up eslint in monorepo project > eslint.config.ts 1`] = `
+"import twoDigits from '@2digits/eslint-config';
+
+export default twoDigits({
+  ignores: {
+    ignores: ['apps/**', 'packages/**'],
+  },
+});
+"
+`;
+
+exports[`EslintSetupService > setup - monorepo > sets up eslint in monorepo project > package.json 1`] = `
+{
+  "devDependencies": {
+    "turbo": "^2.0.0",
+  },
+  "name": "test-monorepo",
+  "packageManager": "pnpm@9.0.0",
+  "private": true,
+  "scripts": {
+    "build": "turbo run build",
+    "lint": "turbo run lint lint:root",
+    "lint:fix": "turbo run lint:fix lint:root:fix",
+    "lint:root": "eslint .",
+    "lint:root:fix": "eslint . --fix",
+  },
+  "type": "module",
+  "version": "1.0.0",
+}
+`;
+
+exports[`EslintSetupService > setup - monorepo > sets up eslint in monorepo project > packages/app/eslint.config.ts 1`] = `
+"import twoDigits from '@2digits/eslint-config';
+
+export default twoDigits();
+"
+`;
+
+exports[`EslintSetupService > setup - monorepo > sets up eslint in monorepo project > turbo.json 1`] = `
+{
+  "tasks": {
+    "//#lint:root": {
+      "outputLogs": "new-only",
+    },
+    "//#lint:root:fix": {},
+    "build": {
+      "dependsOn": [
+        "^build",
+      ],
+      "outputs": [
+        "dist/**",
+      ],
+    },
+    "lint": {
+      "dependsOn": [
+        "topo",
+        "^build",
+      ],
+      "outputLogs": "new-only",
+    },
+    "lint:fix": {},
+    "test": {
+      "dependsOn": [
+        "^test",
+      ],
+    },
+  },
+}
+`;
+
+exports[`EslintSetupService > setup - with existing config > backs up existing eslint config > eslint.config.js.backup 1`] = `
+"import config from "@company/eslint-config"
+
+export default config
+"
+`;
+
+exports[`EslintSetupService > setup - with existing config > backs up existing eslint config > eslint.config.ts 1`] = `
+"import twoDigits from '@2digits/eslint-config';
+
+export default twoDigits();
+"
+`;

--- a/packages/cli/test/unit/services/__snapshots__/PrettierSetupService.test.ts.snap
+++ b/packages/cli/test/unit/services/__snapshots__/PrettierSetupService.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PrettierSetupService > setup > adds prettier config and scripts to package.json 2`] = `
+{
+  "devDependencies": {},
+  "name": "test-single-package",
+  "packageManager": "pnpm@9.0.0",
+  "prettier": "@2digits/prettier-config",
+  "scripts": {
+    "build": "tsc",
+    "format": "prettier . --ignore-unknown --check --cache",
+    "format:fix": "prettier . --ignore-unknown --write --cache",
+    "test": "vitest",
+  },
+  "type": "module",
+  "version": "1.0.0",
+}
+`;
+
+exports[`PrettierSetupService > setup > preserves existing prettier config 1`] = `
+{
+  "devDependencies": {
+    "@company/eslint-config": "^1.0.0",
+    "eslint": "^9.0.0",
+    "prettier": "^3.0.0",
+  },
+  "name": "test-existing-configs",
+  "packageManager": "pnpm@9.0.0",
+  "prettier": "@company/prettier-config",
+  "scripts": {
+    "format": "prettier --check .",
+    "format:fix": "prettier . --ignore-unknown --write --cache",
+    "lint": "eslint .",
+  },
+  "type": "module",
+  "version": "1.0.0",
+}
+`;
+
+exports[`PrettierSetupService > setup > preserves existing scripts 1`] = `
+{
+  "devDependencies": {},
+  "name": "test-single-package",
+  "packageManager": "pnpm@9.0.0",
+  "prettier": "@2digits/prettier-config",
+  "scripts": {
+    "build": "tsc",
+    "format": "custom-format-command",
+    "format:fix": "prettier . --ignore-unknown --write --cache",
+    "test": "vitest",
+  },
+  "type": "module",
+  "version": "1.0.0",
+}
+`;

--- a/packages/cli/test/vitest.setup.ts
+++ b/packages/cli/test/vitest.setup.ts
@@ -1,0 +1,3 @@
+import { addEqualityTesters } from '@effect/vitest';
+
+addEqualityTesters();

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from 'node:path';
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  esbuild: {
+    target: 'es2020',
+  },
+  test: {
+    setupFiles: [path.join(__dirname, 'test/vitest.setup.ts')],
+    include: ['test/**/*.test.ts'],
+    fakeTimers: {
+      toFake: undefined,
+    },
+    sequence: {
+      concurrent: false,
+    },
+  },
+});

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,7 +26,8 @@
     "types": "tsc --noEmit",
     "docs": "eslint-config-inspector build",
     "docs:dev": "eslint-config-inspector",
-    "test": "vitest --run"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "eslint-config"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@effect/platform-node':
       specifier: 0.100.0
       version: 0.100.0
+    '@effect/vitest':
+      specifier: 0.27.0
+      version: 0.27.0
     '@eslint-community/eslint-plugin-eslint-comments':
       specifier: 4.5.0
       version: 4.5.0
@@ -343,6 +346,9 @@ importers:
       '@effect/language-service':
         specifier: 'catalog:'
         version: 0.55.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.27.0(effect@3.19.3)(vitest@4.0.8(@types/debug@4.1.12)(@types/node@22.19.0)(jiti@2.6.0)(tsx@4.20.6)(yaml@2.8.1))
       tsdown:
         specifier: 'catalog:'
         version: 0.16.1(oxc-resolver@11.12.0)(synckit@0.11.11)(typescript@5.9.3)
@@ -355,6 +361,9 @@ importers:
       unplugin-replace:
         specifier: 'catalog:'
         version: 0.6.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@22.19.0)(jiti@2.6.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/constants:
     devDependencies:
@@ -1162,6 +1171,12 @@ packages:
     resolution: {integrity: sha512-+8xYvX4tjD7gKwGYzOyFh90I+ptdXzoNHLQTSa8kGh/xOVZMIGYb0VgLoNHE02UsuVrB+JJJuBmKLdd5TeDTPg==}
     peerDependencies:
       effect: ^3.17.0
+
+  '@effect/vitest@0.27.0':
+    resolution: {integrity: sha512-8bM7n9xlMUYw9GqPIVgXFwFm2jf27m/R7psI64PGpwU5+26iwyxp9eAXEsfT5S6lqztYfpQQ1Ubp5o6HfNYzJQ==}
+    peerDependencies:
+      effect: ^3.19.0
+      vitest: ^3.2.0
 
   '@effect/workflow@0.9.3':
     resolution: {integrity: sha512-OGDNoQzKENKMbVIvFOTddI8qwpKf9gmHYadaOMP6gUXQ9dFnRS9/LzV+3ct7IO/roaKTmnUg1BF9hTl9KywSzw==}
@@ -8342,6 +8357,11 @@ snapshots:
   '@effect/typeclass@0.36.0(effect@3.19.3)':
     dependencies:
       effect: 3.19.3
+
+  '@effect/vitest@0.27.0(effect@3.19.3)(vitest@4.0.8(@types/debug@4.1.12)(@types/node@22.19.0)(jiti@2.6.0)(tsx@4.20.6)(yaml@2.8.1))':
+    dependencies:
+      effect: 3.19.3
+      vitest: 4.0.8(@types/debug@4.1.12)(@types/node@22.19.0)(jiti@2.6.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@effect/workflow@0.9.3(@effect/platform@0.93.0(effect@3.19.3))(@effect/rpc@0.69.2(@effect/platform@0.93.0(effect@3.19.3))(effect@3.19.3))(effect@3.19.3)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ catalog:
   '@effect/language-service': 0.55.2
   '@effect/platform': 0.93.0
   '@effect/platform-node': 0.100.0
+  '@effect/vitest': 0.27.0
   '@eslint-community/eslint-plugin-eslint-comments': 4.5.0
   '@eslint-react/eslint-plugin': 2.3.1
   '@eslint/compat': 1.4.1

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,12 @@
       "outputs": ["tsconfig.tsbuildinfo"]
     },
     "test": {
-      "dependsOn": ["^test"]
+      "dependsOn": ["^test"],
+      "outputs": ["coverage/**", "node_modules/.vitest/**"]
+    },
+    "test:watch": {
+      "persistent": true,
+      "cache": false
     },
     "dev": {
       "persistent": true
@@ -34,6 +39,12 @@
     },
     "//#knip": {
       "dependsOn": ["@2digits/eslint-config#build", "@2digits/prettier-config#build"]
-    }
+    },
+    "lint": {
+      "dependsOn": ["topo", "^build"],
+      "outputLogs": "new-only"
+    },
+    "lint:fix": {},
+    "//#lint:root:fix": {}
   }
 }


### PR DESCRIPTION
# Add testing infrastructure to CLI package

This PR adds comprehensive testing infrastructure to the CLI package, including:

- Setup Vitest for unit testing
- Create test fixtures for different project types (single package, monorepo, existing configs)
- Implement mock services for testing, including a MockCommandExecutor
- Add test helpers for creating temporary test environments
- Add unit tests for core services:
  - EslintDetectionService
  - EslintSetupService
  - PackageManagerService
  - PrettierSetupService
  - ProjectDetectionService

The PR also adds a CurrentWorkingDirService to make the cwd injectable and testable, improving the testability of services that interact with the file system.

Updates to the knip configuration ensure test fixtures are properly ignored during unused file detection.