### PR TITLE
🔄 Add NPM registry URL and permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     name: 🦋 Changesets
@@ -29,6 +33,7 @@ jobs:
         with:
           node-version: 24.12.0
           cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
 
       - name: 📂 Get pnpm store directory
         shell: bash


### PR DESCRIPTION
Added permissions and registry URL configuration to the release workflow. This PR adds explicit permissions for the GitHub workflow (`id-token: write` and `contents: read`) and configures the Node.js setup action to use the npm registry URL (`registry-url: 'https://registry.npmjs.org'`), ensuring proper authentication and access during the release process.