### PR TITLE
🔄 Update dependencies and bump Beads to 0.30.3

### DIFF
--- a/.changeset/tasty-rivers-admire.md
+++ b/.changeset/tasty-rivers-admire.md
@@ -1,0 +1,7 @@
+---
+'@2digits/cli': patch
+'@2digits/eslint-config': patch
+'@2digits/renovate-config': patch
+---
+
+Updated dependencies

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,8 @@
 [tools]
   "npm:@fission-ai/openspec" = "0.16.0"
-  "ubi:steveyegge/beads" = { version = "0.30.0", exe = "bd" }
+  "ubi:steveyegge/beads" = { version = "0.30.3", exe = "bd" }
   node = "24.12.0"
-  pnpm = "10.26.0"
+  pnpm = "10.26.1"
 
 [env]
   FORCE_COLOR = "1"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "turbo": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@10.26.0",
+  "packageManager": "pnpm@10.26.1",
   "engines": {
     "node": "24.12.0"
   },

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -1802,7 +1802,7 @@ Backward pagination arguments
    */
   'next/inline-script-id'?: Linter.RuleEntry<[]>
   /**
-   * Prefer `next/script` component when using the inline script for Google Analytics.
+   * Prefer `@next/third-parties/google` when using the inline script for Google Analytics and Tag Manager.
    * @see https://nextjs.org/docs/messages/next-script-for-ga
    */
   'next/next-script-for-ga'?: Linter.RuleEntry<[]>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,17 +13,17 @@ catalogs:
       specifier: 2.29.8
       version: 2.29.8
     '@effect/cli':
-      specifier: 0.72.1
-      version: 0.72.1
+      specifier: 0.73.0
+      version: 0.73.0
     '@effect/language-service':
       specifier: 0.62.4
       version: 0.62.4
     '@effect/platform':
-      specifier: 0.93.8
-      version: 0.93.8
+      specifier: 0.94.0
+      version: 0.94.0
     '@effect/platform-node':
-      specifier: 0.103.0
-      version: 0.103.0
+      specifier: 0.104.0
+      version: 0.104.0
     '@effect/vitest':
       specifier: 0.27.0
       version: 0.27.0
@@ -58,8 +58,8 @@ catalogs:
       specifier: 0.25.1
       version: 0.25.1
     '@next/eslint-plugin-next':
-      specifier: 16.0.10
-      version: 16.0.10
+      specifier: 16.1.0
+      version: 16.1.0
     '@prettier/plugin-oxc':
       specifier: 0.1.3
       version: 0.1.3
@@ -91,8 +91,8 @@ catalogs:
       specifier: 1.7.1
       version: 1.7.1
     effect:
-      specifier: 3.19.12
-      version: 3.19.12
+      specifier: 3.19.13
+      version: 3.19.13
     empathic:
       specifier: 2.0.0
       version: 2.0.0
@@ -184,8 +184,8 @@ catalogs:
       specifier: 2.4.2
       version: 2.4.2
     knip:
-      specifier: 5.75.1
-      version: 5.75.1
+      specifier: 5.75.2
+      version: 5.75.2
     local-pkg:
       specifier: 1.1.2
       version: 1.1.2
@@ -220,8 +220,8 @@ catalogs:
       specifier: 19.2.3
       version: 19.2.3
     renovate:
-      specifier: 42.64.0
-      version: 42.64.0
+      specifier: 42.64.1
+      version: 42.64.1
     tailwind-csstree:
       specifier: 0.1.4
       version: 0.1.4
@@ -311,7 +311,7 @@ importers:
         version: 9.39.2(jiti@2.6.0)
       knip:
         specifier: 'catalog:'
-        version: 5.75.1(@types/node@24.10.4)(typescript@5.9.3)
+        version: 5.75.2(@types/node@24.10.4)(typescript@5.9.3)
       pkg-pr-new:
         specifier: 'catalog:'
         version: 0.0.62
@@ -329,16 +329,16 @@ importers:
     dependencies:
       '@effect/cli':
         specifier: 'catalog:'
-        version: 0.72.1(@effect/platform@0.93.8(effect@3.19.12))(@effect/printer-ansi@0.45.0(@effect/typeclass@0.36.0(effect@3.19.12))(effect@3.19.12))(@effect/printer@0.45.0(@effect/typeclass@0.36.0(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)
+        version: 0.73.0(@effect/platform@0.94.0(effect@3.19.13))(@effect/printer-ansi@0.45.0(@effect/typeclass@0.36.0(effect@3.19.13))(effect@3.19.13))(@effect/printer@0.45.0(@effect/typeclass@0.36.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)
       '@effect/platform':
         specifier: 'catalog:'
-        version: 0.93.8(effect@3.19.12)
+        version: 0.94.0(effect@3.19.13)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 0.103.0(@effect/cluster@0.48.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/workflow@0.9.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)
+        version: 0.104.0(@effect/cluster@0.48.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/workflow@0.9.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)
       effect:
         specifier: 'catalog:'
-        version: 3.19.12
+        version: 3.19.13
       nypm:
         specifier: 'catalog:'
         version: 0.6.2
@@ -357,7 +357,7 @@ importers:
         version: 0.62.4
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 0.27.0(effect@3.19.12)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(jiti@2.6.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.27.0(effect@3.19.13)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(jiti@2.6.0)(tsx@4.21.0)(yaml@2.8.2))
       publint:
         specifier: 'catalog:'
         version: 0.3.16
@@ -426,7 +426,7 @@ importers:
         version: 4.4.0(@types/node@24.10.4)(crossws@0.3.5)(eslint@9.39.2(jiti@2.6.0))(graphql@16.11.0)(typescript@5.9.3)
       '@next/eslint-plugin-next':
         specifier: 'catalog:'
-        version: 16.0.10
+        version: 16.1.0
       '@stylistic/eslint-plugin':
         specifier: 'catalog:'
         version: 5.6.1(eslint@9.39.2(jiti@2.6.0))
@@ -675,7 +675,7 @@ importers:
         version: 1.0.44
       renovate:
         specifier: 'catalog:'
-        version: 42.64.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 42.64.1(encoding@0.1.13)(typanion@3.14.0)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1135,13 +1135,13 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@effect/cli@0.72.1':
-    resolution: {integrity: sha512-HGDMGD23TxFW9tCSX6g+M2u0robikMA0mP0SqeJMj7FWXTdcQ+cQsJE99bxi9iu+5YID7MIrVJMs8TUwXUV2sg==}
+  '@effect/cli@0.73.0':
+    resolution: {integrity: sha512-KkRtFjfyG52kQ6Z3ZEjwytfKZQACsLzn/RI2jKKxMJDebY9BQganOiE3VGCT4slU3Zisur6SP//ghM0vCLQs4g==}
     peerDependencies:
-      '@effect/platform': ^0.93.0
+      '@effect/platform': ^0.94.0
       '@effect/printer': ^0.47.0
       '@effect/printer-ansi': ^0.47.0
-      effect: ^3.19.3
+      effect: ^3.19.13
 
   '@effect/cluster@0.48.3':
     resolution: {integrity: sha512-fXsGHypOshCkOr1z5WhbYkQfsRR5YVhFk0T+wb5uymNiWTfVqnx7r4zdFAM5nvnulSZFkRTdDLIO8YYBw1HrDg==}
@@ -1169,28 +1169,28 @@ packages:
     resolution: {integrity: sha512-IPe/oGOILtzUIUdhhaz6e2JcnGymPADnjI03f1xOe+LaPLDg/AsRmkY87jhbtb/6qg8NVzlU+ZK4s0JoIMW/yQ==}
     hasBin: true
 
-  '@effect/platform-node-shared@0.56.0':
-    resolution: {integrity: sha512-0RawLcUCLHVGs4ch1nY26P4xM+U6R03ZR02MgNHMsL0slh8YYlal5PnwD/852rJ59O9prQX3Kq8zs+cGVoLAJw==}
+  '@effect/platform-node-shared@0.57.0':
+    resolution: {integrity: sha512-QXuvmLNlABCQLcTl+lN1YPhKosR6KqArPYjC2reU0fb5lroCo3YRb/aGpXIgLthHzQL8cLU5XMGA3Cu5hKY2Tw==}
     peerDependencies:
-      '@effect/cluster': ^0.55.0
-      '@effect/platform': ^0.93.6
-      '@effect/rpc': ^0.72.2
-      '@effect/sql': ^0.48.6
-      effect: ^3.19.8
+      '@effect/cluster': ^0.56.0
+      '@effect/platform': ^0.94.0
+      '@effect/rpc': ^0.73.0
+      '@effect/sql': ^0.49.0
+      effect: ^3.19.13
 
-  '@effect/platform-node@0.103.0':
-    resolution: {integrity: sha512-N2JmOvHInHAC+JFdt+ME8/Pn9vdgBwYTTcqlSXkT+mBzq6fAKdwHkXHoFUMbk8bWtJGx70oezLLEetatjsveaA==}
+  '@effect/platform-node@0.104.0':
+    resolution: {integrity: sha512-2ZkUDDTxLD95ARdYIKBx4tdIIgqA3cwb3jlnVVBxmHUf0Pg5N2HdMuD0Q+CXQ7Q94FDwnLW3ZvaSfxDh6FvrNw==}
     peerDependencies:
-      '@effect/cluster': ^0.55.0
-      '@effect/platform': ^0.93.6
-      '@effect/rpc': ^0.72.2
-      '@effect/sql': ^0.48.6
-      effect: ^3.19.8
+      '@effect/cluster': ^0.56.0
+      '@effect/platform': ^0.94.0
+      '@effect/rpc': ^0.73.0
+      '@effect/sql': ^0.49.0
+      effect: ^3.19.13
 
-  '@effect/platform@0.93.8':
-    resolution: {integrity: sha512-xTEy6fyTy4ijmFC3afKgtvYtn/JyPoIov4ZSUWJZUv3VeOcUPNGrrqG6IJlWkXs3NhvSywKv7wc1kw3epCQVZw==}
+  '@effect/platform@0.94.0':
+    resolution: {integrity: sha512-oIATd3M+RUe2q+bu0Qpgt4/qSbXBM9OEGBrRW7SvtwXGOWkCYkN+LfOPnmPrbMB7jYjpIb7808T1bONM1Nwgfg==}
     peerDependencies:
-      effect: ^3.19.12
+      effect: ^3.19.13
 
   '@effect/printer-ansi@0.45.0':
     resolution: {integrity: sha512-3MS02RP83eZaBJX98PRI4f5kyoEVyNfg2Qu/XUWQMFRp4wvmgNwEy18RjO9G6s7uB8NaYXTpQVDmtUoKARx7fA==}
@@ -2012,8 +2012,8 @@ packages:
   '@napi-rs/wasm-runtime@1.1.0':
     resolution: {integrity: sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==}
 
-  '@next/eslint-plugin-next@16.0.10':
-    resolution: {integrity: sha512-b2NlWN70bbPLmfyoLvvidPKWENBYYIe017ZGUpElvQjDytCWgxPJx7L9juxHt0xHvNVA08ZHJdOyhGzon/KJuw==}
+  '@next/eslint-plugin-next@16.1.0':
+    resolution: {integrity: sha512-sooC/k0LCF4/jLXYHpgfzJot04lZQqsttn8XJpTguP8N3GhqXN3wSkh68no2OcZzS/qeGwKDFTqhZ8WofdXmmQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4189,8 +4189,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  effect@3.19.12:
-    resolution: {integrity: sha512-7F9RGTrCTC3D7nh9Zw+3VlJWwZgo5k33KA+476BAaD0rKIXKZsY/jQ+ipyhR/Avo239Fi6GqAVFs1mqM1IJ7yg==}
+  effect@3.19.13:
+    resolution: {integrity: sha512-8MZ783YuHRwHZX2Mmm+bpGxq+7XPd88sWwYAz2Ysry80sEKpftDZXs2Hg9ZyjESi1IBTNHF0oDKe0zJRkUlyew==}
 
   electron-to-chromium@1.5.211:
     resolution: {integrity: sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==}
@@ -5251,8 +5251,8 @@ packages:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
 
-  knip@5.75.1:
-    resolution: {integrity: sha512-raguBFxTUO5JKrv8rtC8wrOtzrDwWp/fOu1F1GhrHD1F3TD2fqI1Z74JB+PyFZubL+RxqOkhGStdPAvaaXSOWQ==}
+  knip@5.75.2:
+    resolution: {integrity: sha512-ZSO9gGKG/RztUYawrMbPTqO9VG3qvTW/ddINJqYM+N+9F/0bX6HEBolo8+HKaBuTIgyM4dn2rZ8M+JLObRdzog==}
     engines: {node: '>=18.18.0'}
     hasBin: true
     peerDependencies:
@@ -6344,8 +6344,8 @@ packages:
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
 
-  renovate@42.64.0:
-    resolution: {integrity: sha512-BxKPbWsAmGPNI2MnMsWvnVwrzl5+eS48Kvo+3rQ74vfA60UQJ56HkDw6ctcn8hFTouRhp7BPqdsW4ZNnBjkTsA==}
+  renovate@42.64.1:
+    resolution: {integrity: sha512-5KU+VlbDnVAHjarpr/+Up1mF3JMoyiuo97iCmwJdsLZRqM2PABatg3uAfHlu82m5nufXySW9C6CaaXA1ZKhMDg==}
     engines: {node: ^22.13.0 || ^24.11.0, pnpm: ^10.0.0}
     hasBin: true
 
@@ -7290,8 +7290,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  xmldoc@2.0.2:
-    resolution: {integrity: sha512-UiRwoSStEXS3R+YE8OqYv3jebza8cBBAI2y8g3B15XFkn3SbEOyyLnmPHjLBPZANrPJKEzxxB7A3XwcLikQVlQ==}
+  xmldoc@2.0.3:
+    resolution: {integrity: sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==}
     engines: {node: '>=12.0.0'}
 
   xtend@4.0.2:
@@ -8562,54 +8562,54 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@effect/cli@0.72.1(@effect/platform@0.93.8(effect@3.19.12))(@effect/printer-ansi@0.45.0(@effect/typeclass@0.36.0(effect@3.19.12))(effect@3.19.12))(@effect/printer@0.45.0(@effect/typeclass@0.36.0(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)':
+  '@effect/cli@0.73.0(@effect/platform@0.94.0(effect@3.19.13))(@effect/printer-ansi@0.45.0(@effect/typeclass@0.36.0(effect@3.19.13))(effect@3.19.13))(@effect/printer@0.45.0(@effect/typeclass@0.36.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/platform': 0.93.8(effect@3.19.12)
-      '@effect/printer': 0.45.0(@effect/typeclass@0.36.0(effect@3.19.12))(effect@3.19.12)
-      '@effect/printer-ansi': 0.45.0(@effect/typeclass@0.36.0(effect@3.19.12))(effect@3.19.12)
-      effect: 3.19.12
+      '@effect/platform': 0.94.0(effect@3.19.13)
+      '@effect/printer': 0.45.0(@effect/typeclass@0.36.0(effect@3.19.13))(effect@3.19.13)
+      '@effect/printer-ansi': 0.45.0(@effect/typeclass@0.36.0(effect@3.19.13))(effect@3.19.13)
+      effect: 3.19.13
       ini: 4.1.3
       toml: 3.0.0
-      yaml: 2.8.1
+      yaml: 2.8.2
 
-  '@effect/cluster@0.48.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/workflow@0.9.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)':
+  '@effect/cluster@0.48.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/workflow@0.9.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/platform': 0.93.8(effect@3.19.12)
-      '@effect/rpc': 0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)
-      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)
-      '@effect/workflow': 0.9.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)
-      effect: 3.19.12
+      '@effect/platform': 0.94.0(effect@3.19.13)
+      '@effect/rpc': 0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)
+      '@effect/workflow': 0.9.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)
+      effect: 3.19.13
 
-  '@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)':
+  '@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/platform': 0.93.8(effect@3.19.12)
-      effect: 3.19.12
+      '@effect/platform': 0.94.0(effect@3.19.13)
+      effect: 3.19.13
       uuid: 11.1.0
 
   '@effect/language-service@0.62.4': {}
 
-  '@effect/platform-node-shared@0.56.0(@effect/cluster@0.48.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/workflow@0.9.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)':
+  '@effect/platform-node-shared@0.57.0(@effect/cluster@0.48.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/workflow@0.9.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/cluster': 0.48.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/workflow@0.9.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)
-      '@effect/platform': 0.93.8(effect@3.19.12)
-      '@effect/rpc': 0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)
-      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)
+      '@effect/cluster': 0.48.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/workflow@0.9.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)
+      '@effect/platform': 0.94.0(effect@3.19.13)
+      '@effect/rpc': 0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)
       '@parcel/watcher': 2.5.1
-      effect: 3.19.12
+      effect: 3.19.13
       multipasta: 0.2.7
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.103.0(@effect/cluster@0.48.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/workflow@0.9.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)':
+  '@effect/platform-node@0.104.0(@effect/cluster@0.48.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/workflow@0.9.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/cluster': 0.48.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/workflow@0.9.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)
-      '@effect/platform': 0.93.8(effect@3.19.12)
-      '@effect/platform-node-shared': 0.56.0(@effect/cluster@0.48.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/workflow@0.9.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)
-      '@effect/rpc': 0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)
-      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)
-      effect: 3.19.12
+      '@effect/cluster': 0.48.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/workflow@0.9.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)
+      '@effect/platform': 0.94.0(effect@3.19.13)
+      '@effect/platform-node-shared': 0.57.0(@effect/cluster@0.48.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/workflow@0.9.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)
+      '@effect/rpc': 0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)
+      effect: 3.19.13
       mime: 3.0.0
       undici: 7.15.0
       ws: 8.18.3
@@ -8617,50 +8617,50 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.93.8(effect@3.19.12)':
+  '@effect/platform@0.94.0(effect@3.19.13)':
     dependencies:
-      effect: 3.19.12
+      effect: 3.19.13
       find-my-way-ts: 0.1.6
       msgpackr: 1.11.5
       multipasta: 0.2.7
 
-  '@effect/printer-ansi@0.45.0(@effect/typeclass@0.36.0(effect@3.19.12))(effect@3.19.12)':
+  '@effect/printer-ansi@0.45.0(@effect/typeclass@0.36.0(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/printer': 0.45.0(@effect/typeclass@0.36.0(effect@3.19.12))(effect@3.19.12)
-      '@effect/typeclass': 0.36.0(effect@3.19.12)
-      effect: 3.19.12
+      '@effect/printer': 0.45.0(@effect/typeclass@0.36.0(effect@3.19.13))(effect@3.19.13)
+      '@effect/typeclass': 0.36.0(effect@3.19.13)
+      effect: 3.19.13
 
-  '@effect/printer@0.45.0(@effect/typeclass@0.36.0(effect@3.19.12))(effect@3.19.12)':
+  '@effect/printer@0.45.0(@effect/typeclass@0.36.0(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/typeclass': 0.36.0(effect@3.19.12)
-      effect: 3.19.12
+      '@effect/typeclass': 0.36.0(effect@3.19.13)
+      effect: 3.19.13
 
-  '@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)':
+  '@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/platform': 0.93.8(effect@3.19.12)
-      effect: 3.19.12
+      '@effect/platform': 0.94.0(effect@3.19.13)
+      effect: 3.19.13
 
-  '@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)':
+  '@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/experimental': 0.54.6(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)
-      '@effect/platform': 0.93.8(effect@3.19.12)
-      effect: 3.19.12
+      '@effect/experimental': 0.54.6(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)
+      '@effect/platform': 0.94.0(effect@3.19.13)
+      effect: 3.19.13
       uuid: 11.1.0
 
-  '@effect/typeclass@0.36.0(effect@3.19.12)':
+  '@effect/typeclass@0.36.0(effect@3.19.13)':
     dependencies:
-      effect: 3.19.12
+      effect: 3.19.13
 
-  '@effect/vitest@0.27.0(effect@3.19.12)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(jiti@2.6.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@effect/vitest@0.27.0(effect@3.19.13)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(jiti@2.6.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      effect: 3.19.12
+      effect: 3.19.13
       vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(jiti@2.6.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@effect/workflow@0.9.3(@effect/platform@0.93.8(effect@3.19.12))(@effect/rpc@0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12))(effect@3.19.12)':
+  '@effect/workflow@0.9.3(@effect/platform@0.94.0(effect@3.19.13))(@effect/rpc@0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13))(effect@3.19.13)':
     dependencies:
-      '@effect/platform': 0.93.8(effect@3.19.12)
-      '@effect/rpc': 0.69.2(@effect/platform@0.93.8(effect@3.19.12))(effect@3.19.12)
-      effect: 3.19.12
+      '@effect/platform': 0.94.0(effect@3.19.13)
+      '@effect/rpc': 0.69.2(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)
+      effect: 3.19.13
 
   '@emnapi/core@1.5.0':
     dependencies:
@@ -9467,7 +9467,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/eslint-plugin-next@16.0.10':
+  '@next/eslint-plugin-next@16.1.0':
     dependencies:
       fast-glob: 3.3.1
 
@@ -11651,7 +11651,7 @@ snapshots:
       minimatch: 10.0.1
       semver: 7.7.3
 
-  effect@3.19.12:
+  effect@3.19.13:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2
@@ -12941,7 +12941,7 @@ snapshots:
 
   klona@2.0.6: {}
 
-  knip@5.75.1(@types/node@24.10.4)(typescript@5.9.3):
+  knip@5.75.2(@types/node@24.10.4)(typescript@5.9.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 24.10.4
@@ -14287,7 +14287,7 @@ snapshots:
 
   remove-trailing-separator@1.1.0: {}
 
-  renovate@42.64.0(encoding@0.1.13)(typanion@3.14.0):
+  renovate@42.64.1(encoding@0.1.13)(typanion@3.14.0):
     dependencies:
       '@aws-sdk/client-codecommit': 3.940.0
       '@aws-sdk/client-ec2': 3.940.0
@@ -14405,7 +14405,7 @@ snapshots:
       upath: 2.0.1
       url-join: 5.0.0
       validate-npm-package-name: 7.0.0
-      xmldoc: 2.0.2
+      xmldoc: 2.0.3
       yaml: 2.8.2
       zod: 3.25.76
     optionalDependencies:
@@ -15364,7 +15364,7 @@ snapshots:
 
   ws@8.18.3: {}
 
-  xmldoc@2.0.2:
+  xmldoc@2.0.3:
     dependencies:
       sax: 1.4.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,10 +7,10 @@ packages:
 catalog:
   '@arethetypeswrong/core': 0.18.2
   '@changesets/cli': 2.29.8
-  '@effect/cli': 0.72.1
-  '@effect/language-service': 0.62.3
-  '@effect/platform': 0.93.8
-  '@effect/platform-node': 0.103.0
+  '@effect/cli': 0.73.0
+  '@effect/language-service': 0.62.4
+  '@effect/platform': 0.94.0
+  '@effect/platform-node': 0.104.0
   '@effect/vitest': 0.27.0
   '@eslint-community/eslint-plugin-eslint-comments': 4.5.0
   '@eslint-react/eslint-plugin': 2.3.13
@@ -22,7 +22,7 @@ catalog:
   '@graphql-eslint/eslint-plugin': 4.4.0
   '@ianvs/prettier-plugin-sort-imports': 4.7.0
   '@manypkg/cli': 0.25.1
-  '@next/eslint-plugin-next': 16.0.10
+  '@next/eslint-plugin-next': 16.1.0
   '@prettier/plugin-oxc': 0.1.3
   '@prettier/plugin-xml': 3.4.2
   '@stylistic/eslint-plugin': 5.6.1
@@ -32,8 +32,8 @@ catalog:
   '@types/react': 19.2.7
   '@typescript-eslint/parser': 8.50.0
   '@typescript-eslint/utils': 8.50.0
-  dedent: 1.7.0
-  effect: 3.19.12
+  dedent: 1.7.1
+  effect: 3.19.13
   empathic: 2.0.0
   eslint: 9.39.2
   eslint-config-flat-gitignore: 2.1.0
@@ -53,7 +53,7 @@ catalog:
   eslint-plugin-react-hooks: 7.0.1
   eslint-plugin-regexp: 2.10.0
   eslint-plugin-sonarjs: 3.0.5
-  eslint-plugin-storybook: 10.1.9
+  eslint-plugin-storybook: 10.1.10
   eslint-plugin-tailwindcss: 3.18.2
   eslint-plugin-turbo: 2.6.3
   eslint-plugin-unicorn: 62.0.0
@@ -64,7 +64,7 @@ catalog:
   globals: 16.5.0
   graphql-config: 5.1.5
   jsonc-eslint-parser: 2.4.2
-  knip: 5.74.0
+  knip: 5.75.2
   local-pkg: 1.1.2
   magic-regexp: 0.10.0
   nolyfill: 1.0.44
@@ -76,7 +76,7 @@ catalog:
   prettier-plugin-tailwindcss: 0.7.2
   publint: 0.3.16
   react: 19.2.3
-  renovate: 42.58.0
+  renovate: 42.64.1
   tailwind-csstree: 0.1.4
   tinyexec: 1.0.2
   tinyglobby: 0.2.15
@@ -87,7 +87,7 @@ catalog:
   typescript: 5.9.3
   typescript-eslint: 8.50.0
   unplugin-replace: 0.6.3
-  vitest: 4.0.15
+  vitest: 4.0.16
   yaml-eslint-parser: 1.3.2
 
 catalogMode: strict


### PR DESCRIPTION
# Updated Dependencies

This PR updates various dependencies across the project:

- Upgraded Beads from 0.30.0 to 0.30.3 in mise.toml
- Updated several npm packages:
  - `@effect/language-service` from 0.62.3 to 0.62.4
  - `dedent` from 1.7.0 to 1.7.1
  - `eslint-plugin-storybook` from 10.1.9 to 10.1.10
  - `knip` from 5.74.0 to 5.75.1
  - `renovate` from 42.58.0 to 42.64.0
  - `vitest` from 4.0.15 to 4.0.16

Also added a changeset file to document patch updates for:
- `@2digits/cli`
- `@2digits/eslint-config`
- `@2digits/renovate-config`