### PR TITLE
✨ Add `prefer-inline-array-callbacks` ESLint rule

### DIFF
--- a/.changeset/late-singers-chew.md
+++ b/.changeset/late-singers-chew.md
@@ -1,0 +1,13 @@
+---
+'@2digits/eslint-plugin': minor
+'@2digits/eslint-config': minor
+---
+
+Add `prefer-inline-array-callbacks` rule
+
+- Added new ESLint rule that disallows passing function references to array methods (map, filter, reduce, etc.)
+- Rule auto-fixes by wrapping callbacks: `arr.map(fn)` → `arr.map((element) => fn(element))`
+- Prevents bugs from extra arguments (index, array) being passed unexpectedly
+- Allows `Boolean`, `String`, `Number` etc. as callbacks where safe
+- Disabled `unicorn/no-array-callback-reference` in favor of new rule with better auto-fix support
+- Removed lint-disable comments from CLI services

--- a/.changeset/soft-walls-hug.md
+++ b/.changeset/soft-walls-hug.md
@@ -1,0 +1,10 @@
+---
+'@2digits/eslint-plugin': patch
+---
+
+Improve `prefer-inline-array-callbacks` rule accuracy and performance
+
+- Fixed shadowed builtin detection using scope analysis - rule now correctly reports when local variables shadow `Boolean`, `String`, etc.
+- Added support for `sort` and `toSorted` methods with `(a, b)` parameter names
+- Improved performance with array type caching and AST selector filtering
+- Refactored type checking to use `esTreeNodeToTSNodeMap` directly

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
   "npm:@fission-ai/openspec" = "0.17.2"
-  "github:steveyegge/beads" = { version = "0.37.0", exe = "bd" }
+  "github:steveyegge/beads" = { version = "0.38.0", exe = "bd" }
   node = "24.12.0"
   pnpm = "10.26.2"
 

--- a/packages/cli/src/services/EslintSetupService.ts
+++ b/packages/cli/src/services/EslintSetupService.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/no-array-callback-reference */
-
 import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
 import * as NodePath from '@effect/platform-node/NodePath';
 import * as FileSystem from '@effect/platform/FileSystem';

--- a/packages/cli/src/services/PackageManagerService.ts
+++ b/packages/cli/src/services/PackageManagerService.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/no-array-callback-reference */
 import * as Command from '@effect/platform/Command';
 import * as Path from '@effect/platform/Path';
 import * as Array from 'effect/Array';

--- a/packages/cli/src/services/TurborepoSetupService.ts
+++ b/packages/cli/src/services/TurborepoSetupService.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/no-array-callback-reference */
-
 import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
 import * as NodePath from '@effect/platform-node/NodePath';
 import * as FileSystem from '@effect/platform/FileSystem';

--- a/packages/eslint-config/src/configs/unicorn.ts
+++ b/packages/eslint-config/src/configs/unicorn.ts
@@ -14,9 +14,10 @@ export function unicorn(): Array<TypedFlatConfigItem> {
       rules: {
         ...pluginUnicorn.configs.recommended.rules,
 
-        'unicorn/filename-case': ['off'],
-        'unicorn/prefer-module': ['off'],
-        'unicorn/prevent-abbreviations': ['off'],
+        'unicorn/no-array-callback-reference': 'off',
+        'unicorn/filename-case': 'off',
+        'unicorn/prefer-module': 'off',
+        'unicorn/prevent-abbreviations': 'off',
         'unicorn/prefer-ternary': ['error', 'only-single-line'],
         'unicorn/no-useless-undefined': [
           'error',
@@ -25,7 +26,7 @@ export function unicorn(): Array<TypedFlatConfigItem> {
             checkArrowFunctionBody: false,
           },
         ],
-        'unicorn/prefer-top-level-await': ['off'],
+        'unicorn/prefer-top-level-await': 'off',
       },
     },
   ];

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -9,6 +9,11 @@ export interface RuleOptions {
    */
   '@2digits/if-curly'?: Linter.RuleEntry<[]>
   /**
+   * Disallow passing function references to array methods
+   * @see https://github.com/2digits-agency/configs/tree/main/packages/eslint-plugin/src/rules/prefer-inline-array-callbacks.ts
+   */
+  '@2digits/prefer-inline-array-callbacks'?: Linter.RuleEntry<[]>
+  /**
    * Discourage hoisting event handlers only used once in JSX; prefer inlining
    * @see https://github.com/2digits-agency/configs/tree/main/packages/eslint-plugin/src/rules/prefer-inline-handlers.ts
    */

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@typescript-eslint/scope-manager": "catalog:",
     "@typescript-eslint/utils": "catalog:",
-    "eslint": "catalog:"
+    "eslint": "catalog:",
+    "ts-api-utils": "catalog:"
   },
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -5,6 +5,7 @@ import type { rules } from '../rules';
 export const recommended = {
   rules: {
     '@2digits/if-curly': 'error' as const,
+    '@2digits/prefer-inline-array-callbacks': 'error' as const,
     '@2digits/prefer-inline-handlers': 'error' as const,
     '@2digits/type-param-names': 'error' as const,
   } satisfies Record<`@2digits/${keyof typeof rules}`, Linter.RuleEntry<[]>>,

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,9 +1,11 @@
 import { ifCurly } from './if-curly';
+import { preferInlineArrayCallbacks } from './prefer-inline-array-callbacks';
 import { preferInlineHandlers } from './prefer-inline-handlers';
 import { typeParamNames } from './type-param-names';
 
 export const rules = {
   'if-curly': ifCurly,
+  'prefer-inline-array-callbacks': preferInlineArrayCallbacks,
   'prefer-inline-handlers': preferInlineHandlers,
   'type-param-names': typeParamNames,
 };

--- a/packages/eslint-plugin/src/rules/prefer-inline-array-callbacks.ts
+++ b/packages/eslint-plugin/src/rules/prefer-inline-array-callbacks.ts
@@ -1,0 +1,214 @@
+import { ScopeType } from '@typescript-eslint/scope-manager';
+import { AST_NODE_TYPES, ESLintUtils, type TSESLint, type TSESTree } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+import type ts from 'typescript';
+
+import { createRule } from '../utils';
+
+type MessageId = (typeof MessageId)[keyof typeof MessageId];
+const MessageId = {
+  noCallbackReference: 'noCallbackReference',
+} as const;
+
+export const RULE_NAME = 'prefer-inline-array-callbacks';
+
+const SIMPLE_METHODS = new Map([
+  ['every', new Set(['Boolean'])],
+  ['filter', new Set(['Boolean'])],
+  ['find', new Set(['Boolean'])],
+  ['findLast', new Set(['Boolean'])],
+  ['findIndex', new Set(['Boolean'])],
+  ['findLastIndex', new Set(['Boolean'])],
+  ['flatMap', undefined],
+  ['forEach', undefined],
+  ['map', new Set(['String', 'Number', 'BigInt', 'Boolean', 'Symbol'])],
+  ['some', new Set(['Boolean'])],
+]);
+
+const COMPARE_METHODS = new Set(['sort', 'toSorted']);
+
+const REDUCE_METHODS = new Set(['reduce', 'reduceRight']);
+
+const ALL_METHODS = new Set([...SIMPLE_METHODS.keys(), ...REDUCE_METHODS, ...COMPARE_METHODS]);
+
+const arrayTypeCache = new WeakMap<TSESTree.Node, boolean>();
+
+function isGlobalIdentifier(node: TSESTree.Node, name: string): boolean {
+  return node.type === AST_NODE_TYPES.Identifier && node.name === name;
+}
+
+function isIgnoredCallback(
+  methodName: string,
+  callback: TSESTree.Node,
+  sourceCode: Readonly<TSESLint.SourceCode>,
+): boolean {
+  if (callback.type !== AST_NODE_TYPES.Identifier) {
+    return false;
+  }
+
+  const ignoredCallbacks = SIMPLE_METHODS.get(methodName);
+
+  if (!ignoredCallbacks?.has(callback.name)) {
+    return false;
+  }
+
+  const scope = sourceCode.getScope(callback);
+  const reference = scope.references.find((ref) => ref.identifier === callback);
+
+  if (!reference?.resolved) {
+    return true;
+  }
+
+  return reference.resolved.scope.type === ScopeType.global;
+}
+
+function isInlineFunction(node: TSESTree.Node): boolean {
+  return node.type === AST_NODE_TYPES.ArrowFunctionExpression || node.type === AST_NODE_TYPES.FunctionExpression;
+}
+
+function isBindCall(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.CallExpression
+    && node.callee.type === AST_NODE_TYPES.MemberExpression
+    && isGlobalIdentifier(node.callee.property, 'bind')
+  );
+}
+
+function getCallbackName(node: TSESTree.Node): string {
+  if (node.type === AST_NODE_TYPES.Identifier) {
+    return node.name;
+  }
+
+  if (node.type === AST_NODE_TYPES.MemberExpression) {
+    if (node.property.type === AST_NODE_TYPES.Identifier) {
+      return node.property.name;
+    }
+
+    if (node.property.type === AST_NODE_TYPES.Literal) {
+      return String(node.property.value);
+    }
+  }
+
+  return 'callback';
+}
+
+const needsParenthesesItems = [
+  AST_NODE_TYPES.SequenceExpression,
+  AST_NODE_TYPES.YieldExpression,
+  AST_NODE_TYPES.ArrowFunctionExpression,
+  AST_NODE_TYPES.ConditionalExpression,
+  AST_NODE_TYPES.AssignmentExpression,
+  AST_NODE_TYPES.LogicalExpression,
+  AST_NODE_TYPES.BinaryExpression,
+  AST_NODE_TYPES.UnaryExpression,
+  AST_NODE_TYPES.UpdateExpression,
+] as const;
+
+type NeedsParenthesesNode = Extract<TSESTree.Node, { type: (typeof needsParenthesesItems)[number] }>;
+
+function needsParentheses(node: TSESTree.Node): node is NeedsParenthesesNode {
+  return needsParenthesesItems.includes(node.type as never);
+}
+
+function isArrayType(checker: ts.TypeChecker, type: ts.Type) {
+  return tsutils
+    .unionConstituents(type)
+    .some((unionPart) =>
+      tsutils.intersectionConstituents(unionPart).every((t) => checker.isArrayType(t) || checker.isTupleType(t)),
+    );
+}
+
+export const preferInlineArrayCallbacks = createRule<[], MessageId>({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow passing function references to array methods',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      noCallbackReference:
+        'Do not pass `{{name}}` by reference to `Array#{{method}}`. Array methods pass extra arguments (index, array) which may cause unexpected behavior.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const parserServices = ESLintUtils.getParserServices(context, true);
+
+    if (!parserServices.program || !('getTypeAtLocation' in parserServices)) {
+      return {};
+    }
+
+    const checker = parserServices.program.getTypeChecker();
+
+    function checkArrayMethod(node: TSESTree.CallExpression): void {
+      const { object, property } = node.callee as TSESTree.MemberExpression;
+
+      const methodName = (property as TSESTree.Identifier).name;
+
+      if (!ALL_METHODS.has(methodName)) {
+        return;
+      }
+
+      if (node.arguments.length === 0 || node.arguments.length > 2) {
+        return;
+      }
+
+      const [callback] = node.arguments;
+
+      if (!callback || callback.type === AST_NODE_TYPES.SpreadElement) {
+        return;
+      }
+
+      if (isInlineFunction(callback) || isBindCall(callback)) {
+        return;
+      }
+
+      if (isIgnoredCallback(methodName, callback, context.sourceCode)) {
+        return;
+      }
+
+      let isArray = arrayTypeCache.get(object);
+
+      if (isArray === undefined) {
+        const tsNode = parserServices.esTreeNodeToTSNodeMap.get(object);
+        const objectType = checker.getTypeAtLocation(tsNode);
+
+        isArray = isArrayType(checker, objectType);
+        arrayTypeCache.set(object, isArray);
+      }
+
+      if (!isArray) {
+        return;
+      }
+
+      const callbackName = getCallbackName(callback);
+      const callbackText = context.sourceCode.getText(callback);
+      const wrappedCallback = needsParentheses(callback) ? `(${callbackText})` : callbackText;
+
+      const isReduceMethod = REDUCE_METHODS.has(methodName);
+      const isCompareMethod = COMPARE_METHODS.has(methodName);
+      const params = isReduceMethod ? '(acc, element)' : isCompareMethod ? '(a, b)' : '(element)';
+      const args = isReduceMethod ? 'acc, element' : isCompareMethod ? 'a, b' : 'element';
+
+      const body = methodName === 'forEach' ? `{ ${wrappedCallback}(${args}); }` : `${wrappedCallback}(${args})`;
+
+      const fixedCallback = `${params} => ${body}`;
+
+      context.report({
+        node: callback,
+        messageId: 'noCallbackReference',
+        data: { name: callbackName, method: methodName },
+        fix(fixer) {
+          return fixer.replaceText(callback, fixedCallback);
+        },
+      });
+    }
+
+    return {
+      'CallExpression[callee.type="MemberExpression"][callee.computed=false][callee.property.type="Identifier"]':
+        checkArrayMethod,
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/_test.ts
+++ b/packages/eslint-plugin/tests/_test.ts
@@ -1,9 +1,0 @@
-import tsParser from '@typescript-eslint/parser';
-import { run as _run, type RuleTesterInitOptions, type TestCasesOptions } from 'eslint-vitest-rule-tester';
-
-export function run(options: TestCasesOptions & RuleTesterInitOptions) {
-  return _run({
-    parser: tsParser as never,
-    ...options,
-  });
-}

--- a/packages/eslint-plugin/tests/rules/if-curly.test.ts
+++ b/packages/eslint-plugin/tests/rules/if-curly.test.ts
@@ -1,6 +1,6 @@
-import type { InvalidTestCase, ValidTestCase } from 'eslint-vitest-rule-tester';
+import parser from '@typescript-eslint/parser';
+import { run, type InvalidTestCase, type ValidTestCase } from 'eslint-vitest-rule-tester';
 
-import { run } from '../_test';
 import { ifCurly, RULE_NAME } from '../../src/rules/if-curly';
 
 const javascript = String.raw;
@@ -88,6 +88,7 @@ else {
 ];
 
 await run({
+  parser,
   name: RULE_NAME,
   rule: ifCurly,
   valid: valids,

--- a/packages/eslint-plugin/tests/rules/prefer-inline-array-callbacks.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-inline-array-callbacks.test.ts
@@ -1,0 +1,158 @@
+import parser from '@typescript-eslint/parser';
+import { run, type InvalidTestCase, type ValidTestCase } from 'eslint-vitest-rule-tester';
+
+import { preferInlineArrayCallbacks, RULE_NAME } from '../../src/rules/prefer-inline-array-callbacks';
+
+const typescript = String.raw;
+
+const valids: Array<ValidTestCase> = [
+  typescript`const arr = [1, 2, 3]; arr.map((x) => x * 2)`,
+  typescript`const arr = [1, 2, 3]; arr.map((x) => fn(x))`,
+  typescript`const arr = [1, 2, 3]; arr.filter((x) => predicate(x))`,
+  typescript`const arr = [1, 2, 3]; arr.forEach((x) => { process(x); })`,
+  typescript`const arr = [1, 2, 3]; arr.reduce((acc, x) => acc + x, 0)`,
+
+  typescript`const arr = [1, 2, 3]; arr.filter(Boolean)`,
+  typescript`const arr = [1, 2, 3]; arr.find(Boolean)`,
+  typescript`const arr = [1, 2, 3]; arr.findIndex(Boolean)`,
+  typescript`const arr = [1, 2, 3]; arr.some(Boolean)`,
+  typescript`const arr = [1, 2, 3]; arr.every(Boolean)`,
+
+  typescript`const arr = ['a', 'b']; arr.map(String)`,
+  typescript`const arr = ['1', '2']; arr.map(Number)`,
+  typescript`const arr = [1n, 2n]; arr.map(BigInt)`,
+  typescript`const arr = [true, false]; arr.map(Symbol)`,
+
+  typescript`const arr = [1, 2, 3]; arr.map(fn.bind(this))`,
+  typescript`const arr = [1, 2, 3]; arr.filter(predicate.bind(ctx))`,
+
+  typescript`const arr = [1, 2, 3]; arr['map'](fn)`,
+  typescript`const method = 'map'; arr[method](fn)`,
+
+  typescript`const arr = [1, 2, 3]; arr.map()`,
+  typescript`const arr = [1, 2, 3]; arr.map(fn, ctx, extra)`,
+
+  typescript`class MyArray { map(fn: Function) {} }; const arr = new MyArray(); arr.map(fn)`,
+  typescript`const obj = { map: (fn: Function) => {} }; obj.map(fn)`,
+
+  typescript`const promise = Promise.resolve([1, 2, 3]); promise.then(fn)`,
+  typescript`const set = new Set([1, 2, 3]); set.forEach(fn)`,
+
+  typescript`const arr = [1, 2, 3]; arr?.map((x) => x * 2)`,
+];
+
+const invalids: Array<InvalidTestCase> = [
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.map(fn)`,
+    output: typescript`const arr = [1, 2, 3]; arr.map((element) => fn(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'fn', method: 'map' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.filter(predicate)`,
+    output: typescript`const arr = [1, 2, 3]; arr.filter((element) => predicate(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'predicate', method: 'filter' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.forEach(process)`,
+    output: typescript`const arr = [1, 2, 3]; arr.forEach((element) => { process(element); })`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'process', method: 'forEach' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.reduce(reducer)`,
+    output: typescript`const arr = [1, 2, 3]; arr.reduce((acc, element) => reducer(acc, element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'reducer', method: 'reduce' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.reduceRight(reducer)`,
+    output: typescript`const arr = [1, 2, 3]; arr.reduceRight((acc, element) => reducer(acc, element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'reducer', method: 'reduceRight' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.find(predicate)`,
+    output: typescript`const arr = [1, 2, 3]; arr.find((element) => predicate(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'predicate', method: 'find' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.findLast(predicate)`,
+    output: typescript`const arr = [1, 2, 3]; arr.findLast((element) => predicate(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'predicate', method: 'findLast' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.findIndex(predicate)`,
+    output: typescript`const arr = [1, 2, 3]; arr.findIndex((element) => predicate(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'predicate', method: 'findIndex' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.findLastIndex(predicate)`,
+    output: typescript`const arr = [1, 2, 3]; arr.findLastIndex((element) => predicate(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'predicate', method: 'findLastIndex' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.some(predicate)`,
+    output: typescript`const arr = [1, 2, 3]; arr.some((element) => predicate(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'predicate', method: 'some' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.every(predicate)`,
+    output: typescript`const arr = [1, 2, 3]; arr.every((element) => predicate(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'predicate', method: 'every' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.flatMap(transform)`,
+    output: typescript`const arr = [1, 2, 3]; arr.flatMap((element) => transform(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'transform', method: 'flatMap' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.map(obj.method)`,
+    output: typescript`const arr = [1, 2, 3]; arr.map((element) => obj.method(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'method', method: 'map' } }],
+  },
+  {
+    code: typescript`const tuple: [number, number] = [1, 2]; tuple.map(fn)`,
+    output: typescript`const tuple: [number, number] = [1, 2]; tuple.map((element) => fn(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'fn', method: 'map' } }],
+  },
+  {
+    code: typescript`const arr: Array<number> | Array<string> = [1, 2]; arr.map(fn)`,
+    output: typescript`const arr: Array<number> | Array<string> = [1, 2]; arr.map((element) => fn(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'fn', method: 'map' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.map(a || b)`,
+    output: typescript`const arr = [1, 2, 3]; arr.map((element) => (a || b)(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'callback', method: 'map' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.map(condition ? fnA : fnB)`,
+    output: typescript`const arr = [1, 2, 3]; arr.map((element) => (condition ? fnA : fnB)(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'callback', method: 'map' } }],
+  },
+  {
+    code: typescript`const Boolean = (x) => x > 0; [0, 1, -1].filter(Boolean)`,
+    output: typescript`const Boolean = (x) => x > 0; [0, 1, -1].filter((element) => Boolean(element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'Boolean', method: 'filter' } }],
+  },
+  {
+    code: typescript`const arr = [1, 2, 3]; arr.map(obj['method'])`,
+    output: typescript`const arr = [1, 2, 3]; arr.map((element) => obj['method'](element))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'method', method: 'map' } }],
+  },
+  {
+    code: typescript`const arr = [3, 1, 2]; arr.toSorted(compareFn)`,
+    output: typescript`const arr = [3, 1, 2]; arr.toSorted((a, b) => compareFn(a, b))`,
+    errors: [{ messageId: 'noCallbackReference', data: { name: 'compareFn', method: 'toSorted' } }],
+  },
+];
+
+await run({
+  parser,
+  parserOptions: {
+    projectService: {
+      allowDefaultProject: ['*.ts'],
+    },
+  },
+  name: RULE_NAME,
+  rule: preferInlineArrayCallbacks,
+  valid: valids,
+  invalid: invalids,
+});

--- a/packages/eslint-plugin/tests/rules/prefer-inline-handlers.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-inline-handlers.test.ts
@@ -1,23 +1,7 @@
-import tsParser from '@typescript-eslint/parser';
-import {
-  run as _run,
-  type InvalidTestCase,
-  type RuleTesterInitOptions,
-  type TestCasesOptions,
-  type ValidTestCase,
-} from 'eslint-vitest-rule-tester';
+import parser from '@typescript-eslint/parser';
+import { run, type InvalidTestCase, type ValidTestCase } from 'eslint-vitest-rule-tester';
 
 import { preferInlineHandlers, RULE_NAME } from '../../src/rules/prefer-inline-handlers';
-
-function run(options: TestCasesOptions & RuleTesterInitOptions) {
-  return _run({
-    parser: tsParser as never,
-    parserOptions: {
-      ecmaFeatures: { jsx: true },
-    },
-    ...options,
-  });
-}
 
 const tsx = String.raw;
 
@@ -259,6 +243,10 @@ const invalids: Array<InvalidTestCase> = [
 ];
 
 await run({
+  parser,
+  parserOptions: {
+    ecmaFeatures: { jsx: true },
+  },
   name: RULE_NAME,
   rule: preferInlineHandlers,
   valid: valids,

--- a/packages/eslint-plugin/tests/rules/type-param-names.test.ts
+++ b/packages/eslint-plugin/tests/rules/type-param-names.test.ts
@@ -1,6 +1,6 @@
-import type { InvalidTestCase, ValidTestCase } from 'eslint-vitest-rule-tester';
+import parser from '@typescript-eslint/parser';
+import { run, type InvalidTestCase, type ValidTestCase } from 'eslint-vitest-rule-tester';
 
-import { run } from '../_test';
 import { RULE_NAME, typeParamNames } from '../../src/rules/type-param-names';
 
 const typescript = String.raw;
@@ -96,6 +96,7 @@ const invalids: Array<InvalidTestCase> = [
 ];
 
 await run({
+  parser,
   name: RULE_NAME,
   rule: typeParamNames,
   valid: valids,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,8 +187,8 @@ catalogs:
       specifier: 2.4.2
       version: 2.4.2
     knip:
-      specifier: 5.77.4
-      version: 5.77.4
+      specifier: 5.78.0
+      version: 5.78.0
     local-pkg:
       specifier: 1.1.2
       version: 1.1.2
@@ -220,8 +220,8 @@ catalogs:
       specifier: 19.2.3
       version: 19.2.3
     renovate:
-      specifier: 42.66.8
-      version: 42.66.8
+      specifier: 42.66.9
+      version: 42.66.9
     tailwind-csstree:
       specifier: 0.1.4
       version: 0.1.4
@@ -231,6 +231,9 @@ catalogs:
     tinyglobby:
       specifier: 0.2.15
       version: 0.2.15
+    ts-api-utils:
+      specifier: 2.2.0
+      version: 2.2.0
     tsdown:
       specifier: 0.18.3
       version: 0.18.3
@@ -309,7 +312,7 @@ importers:
         version: 9.39.2(jiti@2.6.0)
       knip:
         specifier: 'catalog:'
-        version: 5.77.4(@types/node@24.10.4)(typescript@5.9.3)
+        version: 5.78.0(@types/node@24.10.4)(typescript@5.9.3)
       pkg-pr-new:
         specifier: 'catalog:'
         version: 0.0.62
@@ -591,6 +594,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.0)
+      ts-api-utils:
+        specifier: 'catalog:'
+        version: 2.2.0(typescript@5.9.3)
     devDependencies:
       '@2digits/tsconfig':
         specifier: workspace:*
@@ -670,7 +676,7 @@ importers:
         version: 1.0.44
       renovate:
         specifier: 'catalog:'
-        version: 42.66.8(encoding@0.1.13)(typanion@3.14.0)
+        version: 42.66.9(encoding@0.1.13)(typanion@3.14.0)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2225,13 +2231,9 @@ packages:
     resolution: {integrity: sha512-r2hF85ct2wwB21j3FiPmoicq/iytkh+W7IgT4J4NvN8BZJWOjzNMXn14Gmd8yEe51CXYgTrjHrZmzXnse5NQAw==}
     engines: {node: '>=12.4.0'}
 
-  '@npmcli/agent@3.0.0':
-    resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
-  '@npmcli/fs@4.0.0':
-    resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  '@npmcli/agent@4.0.0':
+    resolution: {integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@npmcli/fs@5.0.0':
     resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
@@ -2700,10 +2702,6 @@ packages:
   '@parcel/watcher@2.5.1':
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -3616,9 +3614,9 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
-  abbrev@3.0.1:
-    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
@@ -3865,10 +3863,6 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-
-  cacache@19.0.1:
-    resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
 
   cacache@20.0.3:
     resolution: {integrity: sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==}
@@ -4902,10 +4896,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    hasBin: true
-
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
@@ -5247,9 +5237,6 @@ packages:
     peerDependencies:
       ws: '*'
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
@@ -5366,8 +5353,8 @@ packages:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
 
-  knip@5.77.4:
-    resolution: {integrity: sha512-CmRd3UabOBqA4lDUAMA8CJeepIoQPD2qRqq0wCnLz9Z3FTlG1iucZ7puwe+i3zV0gUaIWVYgC8cXoDMZEC+DyA==}
+  knip@5.78.0:
+    resolution: {integrity: sha512-nB7i/fgiJl7WVxdv5lX4ZPfDt9/zrw/lOgZtyioy988xtFhKuFJCRdHWT1Zg9Avc0yaojvnmEuAXU8SeMblKww==}
     engines: {node: '>=18.18.0'}
     hasBin: true
     peerDependencies:
@@ -5449,11 +5436,12 @@ packages:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
 
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
   lru-cache@11.1.0:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.2.4:
+    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -5474,9 +5462,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  make-fetch-happen@14.0.3:
-    resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  make-fetch-happen@15.0.3:
+    resolution: {integrity: sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   map-obj@1.0.1:
     resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
@@ -5697,9 +5685,9 @@ packages:
     resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minipass-fetch@4.0.1:
-    resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  minipass-fetch@5.0.0:
+    resolution: {integrity: sha512-fiCdUALipqgPWrOVTz9fw0XhcazULXOSU6ie40DDbX1F49p1dBrSRBuswndTx1x3vEb/g0FT7vC4c4C2u/mh3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   minipass-flush@1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
@@ -5733,6 +5721,10 @@ packages:
     resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
     engines: {node: '>= 18'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -5742,11 +5734,6 @@ packages:
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5791,6 +5778,9 @@ packages:
 
   nan@2.23.1:
     resolution: {integrity: sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==}
+
+  nan@2.24.0:
+    resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -5855,9 +5845,9 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
-  node-gyp@11.5.0:
-    resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  node-gyp@12.1.0:
+    resolution: {integrity: sha512-W+RYA8jBnhSr2vrTtlPYPc1K+CSjGpVDRZxcqJcERZ8ND3A1ThWPHRwctTx3qC3oW99jt726jhdz3Y6ky87J4g==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   node-html-parser@7.0.1:
@@ -5877,9 +5867,9 @@ packages:
     engines: {node: '>=12.4.0'}
     hasBin: true
 
-  nopt@8.1.0:
-    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   normalize-package-data@2.5.0:
@@ -6080,10 +6070,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
@@ -6272,9 +6258,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  proc-log@5.0.0:
-    resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -6352,8 +6338,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  re2@1.22.3:
-    resolution: {integrity: sha512-002aE82U91DiaUA16U6vbiJusvPXn1OWiQukOxJkVUTXbzrSuQbFNHYKcGw8QK/uifRCfjl2Hd/vXYDanKkmaQ==}
+  re2@1.23.0:
+    resolution: {integrity: sha512-mT7+/Lz+Akjm/C/X6PiaHihcJL92TNNXai/C4c/dfBbhtwMm1uKEEoA2Lz/FF6aBFfQzg5mAyv4BGjM4q44QwQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -6453,8 +6439,8 @@ packages:
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
 
-  renovate@42.66.8:
-    resolution: {integrity: sha512-5LbXWZpKcNB8XG7bUNEsk5BCAP0iESMFCOZiEz3eSxz7S38L+bHj2zSOuZVtC5CxkB8VkJKUc0Pxqi5SFwcvWg==}
+  renovate@42.66.9:
+    resolution: {integrity: sha512-zi126hPtJeq0ASXfVq0wWIpkMN9V1FmbnWX8XFVIEYaATTpLjYp3uk1EAFAHlqk55Vi7MZ6/lF9RAOuoMPpKhg==}
     engines: {node: ^22.13.0 || ^24.11.0, pnpm: ^10.0.0}
     hasBin: true
 
@@ -6694,10 +6680,6 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
-  ssri@12.0.0:
-    resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
   ssri@13.0.0:
     resolution: {integrity: sha512-yizwGBpbCn4YomB2lzhZqrHLJoqFGXihNbib3ozhqF/cIp5ue+xSmOQrjNasEE62hFxsCcg/V/z23t4n8jMEng==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -6828,8 +6810,8 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
 
-  tar@7.4.3:
-    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+  tar@7.5.2:
+    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
 
   term-size@2.2.1:
@@ -6926,6 +6908,12 @@ packages:
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-api-utils@2.2.0:
+    resolution: {integrity: sha512-L6f5oQRAoLU1RwXz0Ab9mxsE7LtxeVB6AIR1lpkZMsOyg/JXeaxBaXa/FVCBZyNr9S9I4wkHrlZTklX+im+WMw==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -7111,17 +7099,9 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unique-filename@4.0.0:
-    resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
   unique-filename@5.0.0:
     resolution: {integrity: sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==}
     engines: {node: ^20.17.0 || >=22.9.0}
-
-  unique-slug@5.0.0:
-    resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
 
   unique-slug@6.0.0:
     resolution: {integrity: sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==}
@@ -7340,9 +7320,9 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
-  which@5.0.0:
-    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  which@6.0.0:
+    resolution: {integrity: sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   why-is-node-running@2.3.0:
@@ -9692,20 +9672,15 @@ snapshots:
     dependencies:
       '@nolyfill/shared': 1.0.44
 
-  '@npmcli/agent@3.0.0':
+  '@npmcli/agent@4.0.0':
     dependencies:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      lru-cache: 10.4.3
+      lru-cache: 11.2.4
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
-    optional: true
-
-  '@npmcli/fs@4.0.0':
-    dependencies:
-      semver: 7.7.3
     optional: true
 
   '@npmcli/fs@5.0.0':
@@ -10104,9 +10079,6 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.1
       '@parcel/watcher-win32-ia32': 2.5.1
       '@parcel/watcher-win32-x64': 2.5.1
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@pkgr/core@0.2.9': {}
 
@@ -11182,7 +11154,7 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  abbrev@3.0.1:
+  abbrev@4.0.0:
     optional: true
 
   acorn-import-attributes@1.9.5(acorn@8.15.0):
@@ -11396,22 +11368,6 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
-
-  cacache@19.0.1:
-    dependencies:
-      '@npmcli/fs': 4.0.0
-      fs-minipass: 3.0.3
-      glob: 10.4.5
-      lru-cache: 10.4.3
-      minipass: 7.1.2
-      minipass-collect: 2.0.1
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      p-map: 7.0.4
-      ssri: 12.0.0
-      tar: 7.4.3
-      unique-filename: 4.0.0
-    optional: true
 
   cacache@20.0.3:
     dependencies:
@@ -12632,16 +12588,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-    optional: true
-
   glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
@@ -12984,13 +12930,6 @@ snapshots:
     dependencies:
       ws: 8.18.3
 
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-    optional: true
-
   jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -13093,7 +13032,7 @@ snapshots:
 
   klona@2.0.6: {}
 
-  knip@5.77.4(@types/node@24.10.4)(typescript@5.9.3):
+  knip@5.78.0(@types/node@24.10.4)(typescript@5.9.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 24.10.4
@@ -13175,10 +13114,10 @@ snapshots:
 
   lowercase-keys@2.0.0: {}
 
-  lru-cache@10.4.3:
-    optional: true
-
   lru-cache@11.1.0: {}
+
+  lru-cache@11.2.4:
+    optional: true
 
   lru-cache@5.1.1:
     dependencies:
@@ -13196,19 +13135,19 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  make-fetch-happen@14.0.3:
+  make-fetch-happen@15.0.3:
     dependencies:
-      '@npmcli/agent': 3.0.0
-      cacache: 19.0.1
+      '@npmcli/agent': 4.0.0
+      cacache: 20.0.3
       http-cache-semantics: 4.2.0
       minipass: 7.1.2
-      minipass-fetch: 4.0.1
+      minipass-fetch: 5.0.0
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
       negotiator: 1.0.0
-      proc-log: 5.0.0
+      proc-log: 6.1.0
       promise-retry: 2.0.1
-      ssri: 12.0.0
+      ssri: 13.0.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -13624,7 +13563,7 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
-  minipass-fetch@4.0.1:
+  minipass-fetch@5.0.0:
     dependencies:
       minipass: 7.1.2
       minipass-sized: 1.0.3
@@ -13664,6 +13603,11 @@ snapshots:
       minipass: 7.1.2
     optional: true
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.2
+    optional: true
+
   mkdirp-classic@0.5.3:
     optional: true
 
@@ -13673,9 +13617,6 @@ snapshots:
     optional: true
 
   mkdirp@1.0.4: {}
-
-  mkdirp@3.0.1:
-    optional: true
 
   mlly@1.8.0:
     dependencies:
@@ -13731,6 +13672,9 @@ snapshots:
   nan@2.23.1:
     optional: true
 
+  nan@2.24.0:
+    optional: true
+
   nanoid@3.3.11: {}
 
   nanoid@5.1.6: {}
@@ -13781,18 +13725,18 @@ snapshots:
       detect-libc: 2.0.4
     optional: true
 
-  node-gyp@11.5.0:
+  node-gyp@12.1.0:
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.2
       graceful-fs: 4.2.11
-      make-fetch-happen: 14.0.3
-      nopt: 8.1.0
-      proc-log: 5.0.0
+      make-fetch-happen: 15.0.3
+      nopt: 9.0.0
+      proc-log: 6.1.0
       semver: 7.7.3
-      tar: 7.4.3
+      tar: 7.5.2
       tinyglobby: 0.2.15
-      which: 5.0.0
+      which: 6.0.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -13810,9 +13754,9 @@ snapshots:
 
   nolyfill@1.0.44: {}
 
-  nopt@8.1.0:
+  nopt@9.0.0:
     dependencies:
-      abbrev: 3.0.1
+      abbrev: 4.0.0
     optional: true
 
   normalize-package-data@2.5.0:
@@ -14039,12 +13983,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
-    optional: true
-
   path-scurry@2.0.0:
     dependencies:
       lru-cache: 11.1.0
@@ -14183,7 +14121,7 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  proc-log@5.0.0:
+  proc-log@6.1.0:
     optional: true
 
   process-nextick-args@2.0.1: {}
@@ -14271,11 +14209,11 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  re2@1.22.3:
+  re2@1.23.0:
     dependencies:
       install-artifact-from-github: 1.4.0
-      nan: 2.23.1
-      node-gyp: 11.5.0
+      nan: 2.24.0
+      node-gyp: 12.1.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -14427,7 +14365,7 @@ snapshots:
 
   remove-trailing-separator@1.1.0: {}
 
-  renovate@42.66.8(encoding@0.1.13)(typanion@3.14.0):
+  renovate@42.66.9(encoding@0.1.13)(typanion@3.14.0):
     dependencies:
       '@aws-sdk/client-codecommit': 3.940.0
       '@aws-sdk/client-ec2': 3.940.0
@@ -14551,7 +14489,7 @@ snapshots:
     optionalDependencies:
       better-sqlite3: 12.5.0
       openpgp: 6.3.0
-      re2: 1.22.3
+      re2: 1.23.0
     transitivePeerDependencies:
       - aws-crt
       - encoding
@@ -14817,11 +14755,6 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
-  ssri@12.0.0:
-    dependencies:
-      minipass: 7.1.2
-    optional: true
-
   ssri@13.0.0:
     dependencies:
       minipass: 7.1.2
@@ -14991,13 +14924,12 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tar@7.4.3:
+  tar@7.5.2:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
       minipass: 7.1.2
-      minizlib: 3.0.2
-      mkdirp: 3.0.1
+      minizlib: 3.1.0
       yallist: 5.0.0
     optional: true
 
@@ -15077,6 +15009,10 @@ snapshots:
   trough@2.2.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  ts-api-utils@2.2.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 
@@ -15246,19 +15182,9 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unique-filename@4.0.0:
-    dependencies:
-      unique-slug: 5.0.0
-    optional: true
-
   unique-filename@5.0.0:
     dependencies:
       unique-slug: 6.0.0
-
-  unique-slug@5.0.0:
-    dependencies:
-      imurmurhash: 0.1.4
-    optional: true
 
   unique-slug@6.0.0:
     dependencies:
@@ -15448,7 +15374,7 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
-  which@5.0.0:
+  which@6.0.0:
     dependencies:
       isexe: 3.1.1
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ catalog:
   globals: 16.5.0
   graphql-config: 5.1.5
   jsonc-eslint-parser: 2.4.2
-  knip: 5.77.4
+  knip: 5.78.0
   local-pkg: 1.1.2
   nolyfill: 1.0.44
   nypm: 0.6.2
@@ -73,11 +73,12 @@ catalog:
   prettier-plugin-tailwindcss: 0.7.2
   publint: 0.3.16
   react: 19.2.3
-  renovate: 42.66.8
+  renovate: 42.66.9
   tailwind-csstree: 0.1.4
   tinyexec: 1.0.2
   tinyglobby: 0.2.15
   tsdown: 0.18.3
+  ts-api-utils: 2.2.0
   tsx: 4.21.0
   turbo: 2.7.2
   typescript: 5.9.3


### PR DESCRIPTION
# Add `prefer-inline-array-callbacks` ESLint rule

This PR adds a new ESLint rule that prevents passing function references directly to array methods like `map`, `filter`, and `reduce`. The rule automatically fixes code by wrapping callbacks in arrow functions.

## Features

- Prevents bugs caused by array methods passing extra arguments (index, array) to callbacks
- Auto-fixes by converting `arr.map(fn)` to `arr.map((element) => fn(element))`
- Allows safe callbacks like `Boolean`, `String`, `Number` to be used directly
- Handles all common array methods: map, filter, reduce, forEach, find, etc.

## Implementation details

- Added comprehensive test suite covering various use cases
- Added dependency on `ts-api-utils` for type checking
- Disabled `unicorn/no-array-callback-reference` in favor of our new rule
- Removed lint-disable comments from CLI services that are no longer needed
- Updated Beads version to 0.38.0

This rule helps prevent subtle bugs that can occur when array methods pass unexpected arguments to callback functions.