### PR TITLE
🔄 Migrate type checking from tsc to tsgo in all packages

### DIFF
--- a/.changeset/grumpy-lies-sniff.md
+++ b/.changeset/grumpy-lies-sniff.md
@@ -1,0 +1,13 @@
+---
+'@2digits/cli': patch
+'@2digits/constants': patch
+'@2digits/eslint-config': patch
+'@2digits/eslint-plugin': patch
+'@2digits/prettier-config': patch
+'@2digits/renovate-config': patch
+---
+
+Migrate type checking from tsc to tsgo
+
+- Replaced `tsc --noEmit` with `tsgo --noEmit` in all package `types` scripts
+- Added `@typescript/native-preview` to devDependencies for tsgo binary

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ tsup.config.bundled_*.mjs
 
 _fixtures
 .claude/settings.local.json
+.opencode/plans

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "dev": "tsdown --watch --config-loader unconfig",
     "test": "vitest run",
     "test:watch": "vitest",
-    "types": "tsc --noEmit"
+    "types": "tsgo --noEmit"
   },
   "license": "MIT",
   "dependencies": {
@@ -42,6 +42,7 @@
     "@arethetypeswrong/core": "catalog:",
     "@effect/language-service": "catalog:",
     "@effect/vitest": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",
     "tsx": "catalog:",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -19,13 +19,14 @@
   "scripts": {
     "build": "tsdown --minify --config-loader unconfig",
     "dev": "tsdown --watch --config-loader unconfig",
-    "types": "tsc --noEmit"
+    "types": "tsgo --noEmit"
   },
   "license": "MIT",
   "public": true,
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
     "@arethetypeswrong/core": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsdown --minify --config-loader unconfig",
     "dev": "tsdown --watch --config-loader unconfig",
-    "types": "tsc --noEmit",
+    "types": "tsgo --noEmit",
     "docs": "eslint-config-inspector build",
     "docs:dev": "eslint-config-inspector",
     "test": "vitest run",
@@ -85,6 +85,7 @@
     "@arethetypeswrong/core": "catalog:",
     "@eslint/config-inspector": "catalog:",
     "@types/react": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "dedent": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-react-hooks": "catalog:",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsdown --minify --config-loader unconfig",
     "dev": "tsdown --watch --config-loader unconfig",
-    "types": "tsc --noEmit",
+    "types": "tsgo --noEmit",
     "test": "vitest --run"
   },
   "keywords": [
@@ -40,6 +40,7 @@
     "@2digits/tsconfig": "workspace:*",
     "@arethetypeswrong/core": "catalog:",
     "@typescript-eslint/parser": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "eslint-vitest-rule-tester": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown --minify --config-loader unconfig",
     "dev": "tsdown --watch --config-loader unconfig",
-    "types": "tsc --noEmit"
+    "types": "tsgo --noEmit"
   },
   "keywords": [
     "prettier-config"
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
     "@arethetypeswrong/core": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",

--- a/packages/renovate/package.json
+++ b/packages/renovate/package.json
@@ -11,12 +11,13 @@
   "scripts": {
     "build": "node --experimental-strip-types build.ts",
     "test": "renovate-config-validator ./default.json ./src/*.json --strict",
-    "types": "tsc --noEmit"
+    "types": "tsgo --noEmit"
   },
   "license": "MIT",
   "public": false,
   "devDependencies": {
     "@2digits/tsconfig": "workspace:*",
+    "@typescript/native-preview": "catalog:",
     "nolyfill": "catalog:",
     "renovate": "catalog:",
     "typescript": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ catalogs:
     '@typescript-eslint/utils':
       specifier: 8.53.0
       version: 8.53.0
+    '@typescript/native-preview':
+      specifier: 7.0.0-dev.20260118.1
+      version: 7.0.0-dev.20260118.1
     dedent:
       specifier: 1.7.1
       version: 1.7.1
@@ -362,12 +365,15 @@ importers:
       '@effect/vitest':
         specifier: 'catalog:'
         version: 0.27.0(effect@3.19.14)(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(jiti@2.6.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260118.1
       publint:
         specifier: 'catalog:'
         version: 0.3.16
       tsdown:
         specifier: 'catalog:'
-        version: 0.19.0(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.19.0(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260118.1)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -389,12 +395,15 @@ importers:
       '@arethetypeswrong/core':
         specifier: 'catalog:'
         version: 0.18.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260118.1
       publint:
         specifier: 'catalog:'
         version: 0.3.16
       tsdown:
         specifier: 'catalog:'
-        version: 0.19.0(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.19.0(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260118.1)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -552,6 +561,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.8
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260118.1
       dedent:
         specifier: 'catalog:'
         version: 1.7.1
@@ -578,7 +590,7 @@ importers:
         version: 0.2.15
       tsdown:
         specifier: 'catalog:'
-        version: 0.19.0(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.19.0(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260118.1)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -613,6 +625,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 'catalog:'
         version: 8.53.0(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.3)
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260118.1
       eslint-vitest-rule-tester:
         specifier: 'catalog:'
         version: 3.0.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.3)(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(jiti@2.6.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -621,7 +636,7 @@ importers:
         version: 0.3.16
       tsdown:
         specifier: 'catalog:'
-        version: 0.19.0(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.19.0(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260118.1)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -659,6 +674,9 @@ importers:
       '@arethetypeswrong/core':
         specifier: 'catalog:'
         version: 0.18.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260118.1
       prettier:
         specifier: 'catalog:'
         version: 3.8.0
@@ -667,7 +685,7 @@ importers:
         version: 0.3.16
       tsdown:
         specifier: 'catalog:'
-        version: 0.19.0(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.19.0(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260118.1)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -677,6 +695,9 @@ importers:
       '@2digits/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260118.1
       nolyfill:
         specifier: 'catalog:'
         version: 1.0.44
@@ -3394,6 +3415,45 @@ packages:
   '@typescript-eslint/visitor-keys@8.53.0':
     resolution: {integrity: sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260118.1':
+    resolution: {integrity: sha512-Rr9xUWiT3g104hFgMoVbVSmqK1rQd7VhxwHgNNiPLkznGSc3zewIZ5uBCA93VV2BwC1/ksodwmA1ZYW7Ae2IIg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260118.1':
+    resolution: {integrity: sha512-vtpp39vH6wbp/ONJigF6KM7v3TTu8BAZo7ntXPgpV0YQ5cpXlnh6gQaQyXDjzlZRl/jdr+DS/76easoXeRpsFA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260118.1':
+    resolution: {integrity: sha512-w32ohkkaBbotPHQttMwzn2l3CO139aTSmIAbDJ1GdbzacDfu1eRHyDaqJ9FpXXF9rkmQxWPIxz8OjpFGoHejQw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260118.1':
+    resolution: {integrity: sha512-JpYWxan5wwdZsiZJLWvDr/8gbIThnR1orOZ9Wb8Oc6cHFpYolwnXxAoCPLVnEcAfjnC6cY7WZvY5Dn0gSQ2Asw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260118.1':
+    resolution: {integrity: sha512-tJuaHEFnKB+V8dkMp9quOjcYs4sbNqwocFyStUN6D6khyYyYDKoKNI68APO4WM0WJ84zMWTyvBDms5uZojftEw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260118.1':
+    resolution: {integrity: sha512-MhLmNq0OYDRIcWui1g1XaY6tcN4GTzD2rABxwMIpdB+sOtl6YBicoSFk0fToZ+2OOUjjeGwlFzW/LDq540n3HQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260118.1':
+    resolution: {integrity: sha512-NkXwyQHr/DKbp3BP8CzS4zhOIAY4CmUTYtadr5yyNsTJvuavBH9A4BKjqE/83ZRYB7O5O+n/2z1C5yl7IJp/qQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260118.1':
+    resolution: {integrity: sha512-A+anwzt5RsbCWglYUCAgrolHO9iWLFl2NtRIwDU2IaIxTt0GsFcvaDe+IjswJGHknE0nJ7TS6DeAwjkDD/14og==}
+    hasBin: true
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -10860,6 +10920,37 @@ snapshots:
       '@typescript-eslint/types': 8.53.0
       eslint-visitor-keys: 4.2.1
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260118.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260118.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260118.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260118.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260118.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260118.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260118.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260118.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260118.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260118.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260118.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260118.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260118.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260118.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260118.1
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -14420,7 +14511,7 @@ snapshots:
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
 
-  rolldown-plugin-dts@0.20.0(oxc-resolver@11.15.0)(rolldown@1.0.0-beta.59)(typescript@5.9.3):
+  rolldown-plugin-dts@0.20.0(@typescript/native-preview@7.0.0-dev.20260118.1)(oxc-resolver@11.15.0)(rolldown@1.0.0-beta.59)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -14432,6 +14523,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-beta.59
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260118.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -14901,7 +14993,7 @@ snapshots:
 
   ts-pattern@5.9.0: {}
 
-  tsdown@0.19.0(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3):
+  tsdown@0.19.0(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260118.1)(oxc-resolver@11.15.0)(publint@0.3.16)(synckit@0.11.11)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -14912,7 +15004,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.3
       rolldown: 1.0.0-beta.59
-      rolldown-plugin-dts: 0.20.0(oxc-resolver@11.15.0)(rolldown@1.0.0-beta.59)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.20.0(@typescript/native-preview@7.0.0-dev.20260118.1)(oxc-resolver@11.15.0)(rolldown@1.0.0-beta.59)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   '@typescript-eslint/parser': 8.53.0
   '@typescript-eslint/scope-manager': 8.53.0
   '@typescript-eslint/utils': 8.53.0
+  '@typescript/native-preview': 7.0.0-dev.20260118.1
   dedent: 1.7.1
   effect: 3.19.14
   empathic: 2.0.0


### PR DESCRIPTION
# Migrate type checking from tsc to tsgo

This PR replaces TypeScript's built-in type checker with the faster tsgo implementation across all packages in the monorepo:

- Replaced `tsc --noEmit` with `tsgo --noEmit` in all package `types` scripts
- Added `@typescript/native-preview` to devDependencies for tsgo binary
- Updated `.gitignore` to exclude `.opencode/plans` directory

This change should improve type checking performance while maintaining the same level of type safety.