### PR TITLE
Add tsdown-migrate skill and update dependencies

### DIFF
--- a/.agents/skills/tsdown-migrate/README.md
+++ b/.agents/skills/tsdown-migrate/README.md
@@ -1,0 +1,69 @@
+# tsdown-migrate Skill
+
+Agent skill that teaches AI coding agents how to migrate projects from [tsup](https://tsup.egoist.dev/) to [tsdown](https://tsdown.dev).
+
+## Installation
+
+This skill is included when you install the tsdown skills:
+
+```bash
+npx skills add rolldown/tsdown
+```
+
+Or install it separately:
+
+```bash
+npx skills add rolldown/tsdown --skill tsdown-migrate
+```
+
+## What's Included
+
+This skill provides AI agents with complete knowledge to perform tsup→tsdown migrations:
+
+- **Option Mappings** - Every tsup option and its tsdown equivalent
+- **Config Transformations** - File renames, import changes, value transforms
+- **Default Differences** - What changed between tsup and tsdown defaults
+- **Unsupported Options** - What to remove and what alternatives exist
+- **Package.json Migration** - Dependency, script, and config field changes
+- **New Features** - tsdown-exclusive features to suggest after migration
+
+## Usage
+
+Once installed, AI agents will use this knowledge when:
+
+- Migrating tsup projects to tsdown
+- Explaining differences between tsup and tsdown
+- Troubleshooting post-migration build issues
+- Advising on tsdown configuration after migration
+
+### Example Prompts
+
+```
+Migrate my tsup project to tsdown
+```
+
+```
+What are the differences between tsup and tsdown options?
+```
+
+```
+Convert my tsup.config.ts to tsdown format
+```
+
+```
+My build broke after migrating from tsup — help me fix it
+```
+
+## Documentation
+
+- [tsdown Documentation](https://tsdown.dev)
+- [Migration Guide](https://tsdown.dev/guide/migrate-from-tsup)
+- [GitHub Repository](https://github.com/rolldown/tsdown)
+
+## Related Skills
+
+- [tsdown](https://github.com/rolldown/tsdown/tree/main/skills/tsdown) - Core tsdown skill for building and configuring TypeScript libraries
+
+## License
+
+MIT

--- a/.agents/skills/tsdown-migrate/SKILL.md
+++ b/.agents/skills/tsdown-migrate/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: tsdown-migrate
+description: Migrate TypeScript library projects from tsup to tsdown. Provides complete option mappings, config transformation rules, default value differences, and unsupported option alternatives so AI agents can intelligently perform migrations.
+---
+
+# Migrating from tsup to tsdown
+
+Knowledge base for AI agents to migrate tsup projects to tsdown — the Rolldown-powered library bundler.
+
+## When to Use
+
+- Migrating a project from tsup to tsdown
+- Understanding differences between tsup and tsdown options
+- Reviewing or fixing post-migration configuration issues
+- Advising users on tsup→tsdown compatibility
+
+## Migration Overview
+
+Follow these steps to migrate a tsup project:
+
+1. **Rename config file**: `tsup.config.*` → `tsdown.config.*`
+2. **Update imports**: `'tsup'` → `'tsdown'`
+3. **Apply option mappings**: Rename/transform options per tables below
+4. **Preserve tsup defaults**: Explicitly set options that differ (format, clean, dts, target)
+5. **Update package.json**: Dependencies, scripts, root config field
+6. **Remove unsupported options**: Replace with alternatives where available
+7. **Test build**: Run `tsdown` and verify output
+
+## Config File Migration
+
+### File Rename
+
+| tsup | tsdown |
+|------|--------|
+| `tsup.config.ts` | `tsdown.config.ts` |
+| `tsup.config.cts` | `tsdown.config.cts` |
+| `tsup.config.mts` | `tsdown.config.mts` |
+| `tsup.config.js` | `tsdown.config.js` |
+| `tsup.config.cjs` | `tsdown.config.cjs` |
+| `tsup.config.mjs` | `tsdown.config.mjs` |
+| `tsup.config.json` | `tsdown.config.json` |
+
+### Import and Identifier Changes
+
+```ts
+// Before
+import { defineConfig } from 'tsup'
+
+// After
+import { defineConfig } from 'tsdown'
+```
+
+Replace all identifiers: `tsup` → `tsdown`, `TSUP` → `TSDOWN`.
+
+## Option Mappings
+
+### Property Renames
+
+| tsup | tsdown | Notes |
+|------|--------|-------|
+| `cjsInterop` | `cjsDefault` | CJS default export handling |
+| `esbuildPlugins` | `plugins` | Now uses Rolldown/Unplugin plugins |
+
+### Deprecated but Compatible
+
+These tsup options still work in tsdown for backward compatibility, but emit deprecation warnings and **will be removed in a future version**. Migrate them immediately.
+
+| tsup (deprecated) | tsdown (preferred) | Notes |
+|--------------------|--------------------|-------|
+| `entryPoints` | `entry` | Also deprecated in tsup itself |
+| `publicDir` | `copy` | Copy static files to output |
+| `bundle: true` | _(remove)_ | Bundle is default behavior |
+| `bundle: false` | `unbundle: true` | Preserve file structure |
+| `removeNodeProtocol: true` | `nodeProtocol: 'strip'` | Strip `node:` prefix |
+| `injectStyle: true` | `css: { inject: true }` | CSS injection |
+| `injectStyle: false` | _(remove)_ | Default behavior |
+| `external: [...]` | `deps: { neverBundle: [...] }` | Moved to deps namespace |
+| `noExternal: [...]` | `deps: { alwaysBundle: [...] }` | Moved to deps namespace |
+| `skipNodeModulesBundle` | `deps: { skipNodeModulesBundle: true }` | Moved to deps namespace |
+
+### Dependency Namespace Moves
+
+Dependencies config moved under `deps` namespace. If both `external` and `noExternal` exist, merge into a single `deps` object:
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  external: ['react'],
+  noExternal: ['lodash-es'],
+})
+
+// After (tsdown)
+export default defineConfig({
+  deps: {
+    neverBundle: ['react'],
+    alwaysBundle: ['lodash-es'],
+  },
+})
+```
+
+tsdown also adds `deps.onlyBundle` (whitelist of allowed bundled packages) — no tsup equivalent.
+
+### Plugin Import Transforms
+
+```ts
+// Before (tsup - esbuild plugins)
+import plugin from 'unplugin-example/esbuild'
+
+// After (tsdown - Rolldown plugins)
+import plugin from 'unplugin-example/rolldown'
+```
+
+All `unplugin-*/esbuild` imports should change to `unplugin-*/rolldown`.
+
+For complete before/after examples of every transformation, see [guide-option-mappings.md](references/guide-option-mappings.md).
+
+## Default Value Differences
+
+tsdown changes several defaults from tsup. When migrating, explicitly set these to preserve tsup behavior, then let the user decide which new defaults to adopt.
+
+| Option | tsup Default | tsdown Default | Migration Action |
+|--------|-------------|----------------|-----------------|
+| `format` | `'cjs'` | `'esm'` | Set `format: 'cjs'` to preserve |
+| `clean` | `false` | `true` | Set `clean: false` to preserve |
+| `dts` | `false` | Auto-enabled if `types`/`typings` in package.json | Set `dts: false` to preserve |
+| `target` | _(none)_ | Auto-reads from `engines.node` in package.json | Set `target: false` to preserve |
+
+After migration, suggest the user review these — tsdown's defaults are generally better:
+- ESM is the modern standard
+- Cleaning output prevents stale files
+- Auto DTS from package.json reduces config
+- Auto target from engines.node ensures consistency
+
+## Unsupported Options
+
+These tsup options have no direct equivalent in tsdown. Remove them and inform the user.
+
+| tsup Option | Status | Alternative |
+|-------------|--------|-------------|
+| `splitting` | Always enabled | Remove — code splitting cannot be disabled in tsdown |
+| `metafile` | Not available | Suggest `devtools: true` for Vite DevTools bundle analysis |
+| `swc` | Not supported | Remove — tsdown uses oxc for transformation (built-in) |
+| `experimentalDts` | Not supported | Use the `dts` option instead |
+| `legacyOutput` | Not supported | Remove — no alternative |
+| `plugins` (tsup experimental) | Incompatible | Migrate to Rolldown plugins manually; tsup's plugin API differs from Rolldown's |
+
+## Package.json Migration
+
+### Scripts
+
+Replace `tsup` and `tsup-node` with `tsdown` in all script commands:
+
+```json
+// Before
+{
+  "scripts": {
+    "build": "tsup src/index.ts",
+    "dev": "tsup --watch"
+  }
+}
+
+// After
+{
+  "scripts": {
+    "build": "tsdown src/index.ts",
+    "dev": "tsdown --watch"
+  }
+}
+```
+
+### Dependencies
+
+| Location | Action |
+|----------|--------|
+| `dependencies.tsup` | Rename to `dependencies.tsdown` |
+| `devDependencies.tsup` | Rename to `devDependencies.tsdown` |
+| `optionalDependencies.tsup` | Rename to `optionalDependencies.tsdown` |
+| `peerDependencies.tsup` | Rename to `peerDependencies.tsdown` |
+| `peerDependenciesMeta.tsup` | Rename to `peerDependenciesMeta.tsdown` |
+
+### Root Config Field
+
+If package.json has a root-level `tsup` field (inline config), rename to `tsdown`:
+
+```json
+// Before
+{ "tsup": { "entry": ["src/index.ts"] } }
+
+// After
+{ "tsdown": { "entry": ["src/index.ts"] } }
+```
+
+For detailed package.json examples, see [guide-package-json.md](references/guide-package-json.md).
+
+## New tsdown Features
+
+After migration, suggest these tsdown-exclusive features to the user:
+
+| Feature | Config | Description |
+|---------|--------|-------------|
+| Node protocol | `nodeProtocol: true \| 'strip'` | Add or strip `node:` prefix on built-in imports |
+| Workspace | `workspace: 'packages/*'` | Build multiple packages in a monorepo |
+| Package exports | `exports: true` | Auto-generate `exports` field in package.json |
+| Package validation | `publint: true`, `attw: true` | Lint package and check type correctness |
+| Executable | `exe: true` | Bundle as Node.js standalone executable (SEA) |
+| DevTools | `devtools: true` | Vite DevTools integration for bundle analysis |
+| Hooks | `hooks: { 'build:done': ... }` | Lifecycle hooks: `build:prepare`, `build:before`, `build:done` |
+| CSS modules | `css: { modules: { ... } }` | Scoped class names for `.module.css` files |
+| Glob import | `globImport: true` | Support `import.meta.glob` (Vite-style) |
+
+For detailed comparisons, see [guide-differences-detailed.md](references/guide-differences-detailed.md).
+
+## References
+
+| Topic | Description | Reference |
+|-------|-------------|-----------|
+| Option Mappings | Complete before/after for every option transform | [guide-option-mappings](references/guide-option-mappings.md) |
+| Detailed Differences | Architecture, features, compatibility comparison | [guide-differences-detailed](references/guide-differences-detailed.md) |
+| Package.json | Dependency, script, and config field migration | [guide-package-json](references/guide-package-json.md) |
+
+## Migration Checklist
+
+Use this checklist when performing a migration:
+
+```
+- [ ] Rename tsup.config.* → tsdown.config.*
+- [ ] Update import from 'tsup' to 'tsdown'
+- [ ] Replace tsup/TSUP identifiers with tsdown/TSDOWN
+- [ ] Apply property renames (cjsInterop→cjsDefault, esbuildPlugins→plugins)
+- [ ] Migrate deprecated options (publicDir→copy, bundle→unbundle, removeNodeProtocol→nodeProtocol, injectStyle→css.inject)
+- [ ] Move external/noExternal/skipNodeModulesBundle into deps namespace
+- [ ] Update unplugin imports from /esbuild to /rolldown
+- [ ] Set explicit defaults to preserve tsup behavior (format, clean, dts, target)
+- [ ] Remove unsupported options (splitting, metafile, swc, etc.)
+- [ ] Update package.json scripts (tsup→tsdown)
+- [ ] Update package.json dependencies
+- [ ] Rename root-level tsup config field if present
+- [ ] Run tsdown and verify build output
+- [ ] Suggest new tsdown features to the user
+```

--- a/.agents/skills/tsdown-migrate/references/guide-differences-detailed.md
+++ b/.agents/skills/tsdown-migrate/references/guide-differences-detailed.md
@@ -1,0 +1,164 @@
+# Detailed Differences: tsdown vs tsup
+
+Comprehensive comparison of tsdown and tsup for understanding migration impact and new capabilities.
+
+## Architecture
+
+| Aspect | tsup | tsdown |
+|--------|------|--------|
+| Core bundler | esbuild (Go) | Rolldown (Rust) |
+| Plugin system | esbuild plugins | Rolldown + Rollup + Unplugin plugins |
+| Type declarations | Single pass | Dual-format with separate CJS dts pass |
+| Package.json integration | Basic | Advanced (auto-exports, validation) |
+| Watch mode | Standard | Enhanced with keyboard shortcuts (`r` rebuild, `q` quit) |
+| Module system | CJS-first | ESM-first |
+
+## Default Value Comparison
+
+| Option | tsup | tsdown | Impact |
+|--------|------|--------|--------|
+| `format` | `'cjs'` | `'esm'` | Output format changes — set explicitly during migration |
+| `clean` | `false` | `true` | Output dir cleaned before build — may surprise users |
+| `dts` | `false` | Auto if `types`/`typings` in package.json | Types generated automatically — usually desired |
+| `target` | _(none)_ | Reads `engines.node` from package.json | Compilation target auto-detected — usually desired |
+
+## Feature Compatibility
+
+### Fully Supported (works the same)
+
+- Multiple entry points (array, object, globs)
+- Multiple formats (ESM, CJS, IIFE, UMD)
+- TypeScript declarations (`dts`)
+- Source maps
+- Minification
+- Watch mode
+- Tree shaking
+- Shims (`__dirname`, `__filename`, `require`)
+- Clean output directory
+- Define (global constants)
+- Banner/footer injection
+- `onSuccess` callback
+
+### Supported with Changes (Renamed)
+
+| Feature | tsup | tsdown | Change |
+|---------|------|--------|--------|
+| CJS interop | `cjsInterop` | `cjsDefault` | Property rename |
+| Plugins | `esbuildPlugins` | `plugins` | Different plugin format (Rolldown) |
+
+### Deprecated but Compatible
+
+These tsup options still work in tsdown but emit deprecation warnings. They will be removed in a future version — migrate immediately.
+
+| Feature | tsup (deprecated) | tsdown (preferred) | Change |
+|---------|-------------------|--------------------|--------|
+| Entry points | `entryPoints` | `entry` | Also deprecated in tsup itself |
+| Copy files | `publicDir` | `copy` | Property rename |
+| Bundleless | `bundle: false` | `unbundle: true` | Inverted logic |
+| Strip node: | `removeNodeProtocol` | `nodeProtocol: 'strip'` | New option with more modes |
+| CSS inject | `injectStyle` | `css: { inject: true }` | Moved to css namespace |
+| External deps | `external` | `deps.neverBundle` | Moved to deps namespace |
+| Inline deps | `noExternal` | `deps.alwaysBundle` | Moved to deps namespace |
+| Skip node_modules | `skipNodeModulesBundle` | `deps.skipNodeModulesBundle` | Moved to deps namespace |
+
+### Not Supported
+
+| Feature | Reason | Alternative |
+|---------|--------|-------------|
+| `splitting: false` | Code splitting always enabled | None — splitting cannot be disabled |
+| `metafile` | Not implemented | `devtools: true` for bundle analysis |
+| `swc` | Uses oxc instead | Built-in, no config needed |
+| `experimentalDts` | Superseded | Use `dts` option |
+| `legacyOutput` | Not implemented | None |
+| `plugins` (tsup API) | Different plugin architecture | Rewrite as Rolldown/Unplugin plugins |
+
+## New Features in tsdown
+
+### Node Protocol Control
+
+```ts
+nodeProtocol: true       // Add node: prefix (fs → node:fs)
+nodeProtocol: 'strip'    // Remove node: prefix (node:fs → fs)
+nodeProtocol: false       // Keep as-is (default)
+```
+
+### Workspace / Monorepo
+
+```ts
+export default defineConfig({
+  workspace: 'packages/*',
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+})
+```
+
+### Auto Package Exports
+
+```ts
+export default defineConfig({
+  exports: true, // Auto-generate package.json exports field
+})
+```
+
+### Package Validation
+
+```ts
+export default defineConfig({
+  publint: true,    // Lint package for common issues
+  attw: true,       // Check "are the types wrong"
+})
+```
+
+### Standalone Executable
+
+```ts
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  exe: true, // Bundle as Node.js SEA
+})
+```
+
+### Vite DevTools
+
+```ts
+export default defineConfig({
+  devtools: true, // Vite DevTools bundle analysis
+})
+```
+
+### Lifecycle Hooks
+
+```ts
+export default defineConfig({
+  hooks: {
+    'build:prepare': async (ctx) => { /* before any build */ },
+    'build:before': async (ctx) => { /* before each format */ },
+    'build:done': async (ctx) => { /* after build, access chunks */ },
+  },
+})
+```
+
+### CSS Modules
+
+```ts
+export default defineConfig({
+  css: {
+    modules: {
+      localsConvention: 'camelCase',
+    },
+  },
+})
+```
+
+### Glob Import
+
+```ts
+export default defineConfig({
+  globImport: true, // Support import.meta.glob (Vite-style)
+})
+```
+
+## Related
+
+- [guide-option-mappings.md](guide-option-mappings.md) - Before/after for every option
+- [guide-package-json.md](guide-package-json.md) - Package.json migration

--- a/.agents/skills/tsdown-migrate/references/guide-option-mappings.md
+++ b/.agents/skills/tsdown-migrate/references/guide-option-mappings.md
@@ -1,0 +1,227 @@
+# Option Mappings: tsup → tsdown
+
+Complete before/after reference for every config option transformation.
+
+## Property Renames
+
+### cjsInterop → cjsDefault
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  cjsInterop: true,
+})
+
+// After (tsdown)
+export default defineConfig({
+  cjsDefault: true,
+})
+```
+
+### esbuildPlugins → plugins
+
+```ts
+// Before (tsup)
+import myPlugin from 'unplugin-example/esbuild'
+
+export default defineConfig({
+  esbuildPlugins: [myPlugin()],
+})
+
+// After (tsdown)
+import myPlugin from 'unplugin-example/rolldown'
+
+export default defineConfig({
+  plugins: [myPlugin()],
+})
+```
+
+Note: All `unplugin-*/esbuild` imports must change to `unplugin-*/rolldown`.
+
+## Deprecated but Compatible
+
+These options still work in tsdown for backward compatibility but emit deprecation warnings. Migrate them immediately — they will be removed in a future version.
+
+### entryPoints → entry
+
+`entryPoints` is also deprecated in tsup itself. Both tsup and tsdown use `entry`.
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  entryPoints: ['src/index.ts', 'src/cli.ts'],
+})
+
+// After (tsdown)
+export default defineConfig({
+  entry: ['src/index.ts', 'src/cli.ts'],
+})
+```
+
+### publicDir → copy
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  publicDir: 'public',
+})
+
+// After (tsdown)
+export default defineConfig({
+  copy: 'public',
+})
+```
+
+### bundle → unbundle
+
+```ts
+// Before (tsup) — bundle: true is default, just remove
+export default defineConfig({
+  bundle: true,
+})
+
+// After (tsdown) — remove entirely
+export default defineConfig({})
+```
+
+```ts
+// Before (tsup) — bundle: false
+export default defineConfig({
+  bundle: false,
+})
+
+// After (tsdown)
+export default defineConfig({
+  unbundle: true,
+})
+```
+
+### removeNodeProtocol → nodeProtocol
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  removeNodeProtocol: true,
+})
+
+// After (tsdown)
+export default defineConfig({
+  nodeProtocol: 'strip',
+})
+```
+
+### injectStyle → css.inject
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  injectStyle: true,
+})
+
+// After (tsdown)
+export default defineConfig({
+  css: { inject: true },
+})
+```
+
+`injectStyle: false` should be removed (it's the default).
+
+### external → deps.neverBundle
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  external: ['react', 'react-dom', /^@myorg\//],
+})
+
+// After (tsdown)
+export default defineConfig({
+  deps: {
+    neverBundle: ['react', 'react-dom', /^@myorg\//],
+  },
+})
+```
+
+### noExternal → deps.alwaysBundle
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  noExternal: ['lodash-es'],
+})
+
+// After (tsdown)
+export default defineConfig({
+  deps: {
+    alwaysBundle: ['lodash-es'],
+  },
+})
+```
+
+### Combined Example
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  external: ['react'],
+  noExternal: ['lodash-es'],
+})
+
+// After (tsdown)
+export default defineConfig({
+  deps: {
+    neverBundle: ['react'],
+    alwaysBundle: ['lodash-es'],
+  },
+})
+```
+
+## Full Migration Example
+
+```ts
+// Before (tsup.config.ts)
+import { defineConfig } from 'tsup'
+import myPlugin from 'unplugin-example/esbuild'
+
+export default defineConfig({
+  entryPoints: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  bundle: true,
+  external: ['react'],
+  noExternal: ['lodash-es'],
+  publicDir: 'public',
+  cjsInterop: true,
+  removeNodeProtocol: true,
+  injectStyle: true,
+  esbuildPlugins: [myPlugin()],
+  splitting: true,
+  clean: true,
+})
+
+// After (tsdown.config.ts)
+import { defineConfig } from 'tsdown'
+import myPlugin from 'unplugin-example/rolldown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  deps: {
+    neverBundle: ['react'],
+    alwaysBundle: ['lodash-es'],
+  },
+  copy: 'public',
+  cjsDefault: true,
+  nodeProtocol: 'strip',
+  css: { inject: true },
+  plugins: [myPlugin()],
+  // splitting removed — always enabled in tsdown
+  clean: true,
+})
+```
+
+## Related
+
+- [guide-differences-detailed.md](guide-differences-detailed.md) - Architecture and feature comparison
+- [guide-package-json.md](guide-package-json.md) - Package.json migration

--- a/.agents/skills/tsdown-migrate/references/guide-package-json.md
+++ b/.agents/skills/tsdown-migrate/references/guide-package-json.md
@@ -1,0 +1,92 @@
+# Package.json Migration
+
+How to update package.json when migrating from tsup to tsdown.
+
+## Scripts
+
+Replace all occurrences of `tsup` and `tsup-node` with `tsdown`:
+
+```json
+// Before
+{
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm",
+    "dev": "tsup --watch",
+    "build:node": "tsup-node src/server.ts"
+  }
+}
+
+// After
+{
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs,esm",
+    "dev": "tsdown --watch",
+    "build:node": "tsdown src/server.ts"
+  }
+}
+```
+
+## Dependencies
+
+Rename `tsup` to `tsdown` in whichever dependency field it appears:
+
+```json
+// Before
+{
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0"
+  }
+}
+
+// After
+{
+  "devDependencies": {
+    "tsdown": "^0.21.3",
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+### All Dependency Fields
+
+| Field | tsup version | tsdown version |
+|-------|-------------|----------------|
+| `dependencies` | any | latest tsdown |
+| `devDependencies` | any | latest tsdown |
+| `optionalDependencies` | any | latest tsdown |
+| `peerDependencies` | any | `*` |
+| `peerDependenciesMeta` | rename key only | rename key only |
+
+## Root Config Field
+
+If the project uses inline config in package.json (root-level `tsup` field), rename to `tsdown`:
+
+```json
+// Before
+{
+  "name": "my-lib",
+  "tsup": {
+    "entry": ["src/index.ts"],
+    "format": ["cjs", "esm"],
+    "dts": true
+  }
+}
+
+// After
+{
+  "name": "my-lib",
+  "tsdown": {
+    "entry": ["src/index.ts"],
+    "format": ["cjs", "esm"],
+    "dts": true
+  }
+}
+```
+
+Note: Option mappings (entryPoints→entry, etc.) also apply inside the root config field.
+
+## Related
+
+- [guide-option-mappings.md](guide-option-mappings.md) - Config option transforms
+- [guide-differences-detailed.md](guide-differences-detailed.md) - Feature comparison

--- a/.changeset/afraid-balloons-dance.md
+++ b/.changeset/afraid-balloons-dance.md
@@ -1,0 +1,5 @@
+---
+'@2digits/renovate-config': patch
+---
+
+Update renovate to 43.111.0

--- a/.changeset/crisp-kings-refuse.md
+++ b/.changeset/crisp-kings-refuse.md
@@ -1,0 +1,8 @@
+---
+'@2digits/eslint-config': patch
+---
+
+Update ESLint plugins
+
+- Updated `@tanstack/eslint-plugin-query` to 5.99.0
+- Updated `globals` to 17.5.0

--- a/packages/eslint-config/test/__snapshots__/factory/default.snap.json
+++ b/packages/eslint-config/test/__snapshots__/factory/default.snap.json
@@ -164,7 +164,7 @@
         "sourceType": "module"
       },
       "globals": {
-        "_count": 1240
+        "_count": 1245
       },
       "ecmaVersion": 2022,
       "sourceType": "module"

--- a/packages/eslint-config/test/__snapshots__/factory/full.snap.json
+++ b/packages/eslint-config/test/__snapshots__/factory/full.snap.json
@@ -164,7 +164,7 @@
         "sourceType": "module"
       },
       "globals": {
-        "_count": 1240
+        "_count": 1245
       },
       "ecmaVersion": 2022,
       "sourceType": "module"

--- a/packages/eslint-config/test/__snapshots__/factory/minimal.snap.json
+++ b/packages/eslint-config/test/__snapshots__/factory/minimal.snap.json
@@ -164,7 +164,7 @@
         "sourceType": "module"
       },
       "globals": {
-        "_count": 1240
+        "_count": 1245
       },
       "ecmaVersion": 2022,
       "sourceType": "module"

--- a/packages/eslint-config/test/__snapshots__/factory/next-stack.snap.json
+++ b/packages/eslint-config/test/__snapshots__/factory/next-stack.snap.json
@@ -164,7 +164,7 @@
         "sourceType": "module"
       },
       "globals": {
-        "_count": 1240
+        "_count": 1245
       },
       "ecmaVersion": 2022,
       "sourceType": "module"

--- a/packages/eslint-config/test/__snapshots__/factory/react-only.snap.json
+++ b/packages/eslint-config/test/__snapshots__/factory/react-only.snap.json
@@ -164,7 +164,7 @@
         "sourceType": "module"
       },
       "globals": {
-        "_count": 1240
+        "_count": 1245
       },
       "ecmaVersion": 2022,
       "sourceType": "module"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: 5.10.0
       version: 5.10.0
     '@tanstack/eslint-plugin-query':
-      specifier: 5.97.0
-      version: 5.97.0
+      specifier: 5.99.0
+      version: 5.99.0
     '@tanstack/eslint-plugin-router':
       specifier: 1.161.6
       version: 1.161.6
@@ -106,8 +106,8 @@ catalogs:
       specifier: 8.58.1
       version: 8.58.1
     '@typescript/native-preview':
-      specifier: 7.0.0-dev.20260411.1
-      version: 7.0.0-dev.20260411.1
+      specifier: 7.0.0-dev.20260412.1
+      version: 7.0.0-dev.20260412.1
     '@vitest/eslint-plugin':
       specifier: 1.6.15
       version: 1.6.15
@@ -205,8 +205,8 @@ catalogs:
       specifier: 3.1.0
       version: 3.1.0
     globals:
-      specifier: 17.4.0
-      version: 17.4.0
+      specifier: 17.5.0
+      version: 17.5.0
     graphql-config:
       specifier: 5.1.6
       version: 5.1.6
@@ -214,8 +214,8 @@ catalogs:
       specifier: 3.1.0
       version: 3.1.0
     knip:
-      specifier: 6.4.0
-      version: 6.4.0
+      specifier: 6.4.1
+      version: 6.4.1
     local-pkg:
       specifier: 1.1.2
       version: 1.1.2
@@ -256,8 +256,8 @@ catalogs:
       specifier: 19.2.5
       version: 19.2.5
     renovate:
-      specifier: 43.110.14
-      version: 43.110.14
+      specifier: 43.111.0
+      version: 43.111.0
     tailwind-csstree:
       specifier: 0.3.1
       version: 0.3.1
@@ -358,7 +358,7 @@ importers:
         version: 10.2.0(jiti@2.6.1)
       knip:
         specifier: 'catalog:'
-        version: 6.4.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+        version: 6.4.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
       pkg-pr-new:
         specifier: 'catalog:'
         version: 0.0.66
@@ -410,7 +410,7 @@ importers:
         version: 0.29.0(@voidzero-dev/vite-plus-test@0.1.16(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.7(@types/node@24.12.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(effect@3.21.0)
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       publint:
         specifier: 'catalog:'
         version: 0.3.18
@@ -440,7 +440,7 @@ importers:
         version: 0.18.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       publint:
         specifier: 'catalog:'
         version: 0.3.18
@@ -488,7 +488,7 @@ importers:
         version: 5.10.0(eslint@10.2.0(jiti@2.6.1))
       '@tanstack/eslint-plugin-query':
         specifier: 'catalog:'
-        version: 5.97.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+        version: 5.99.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       '@tanstack/eslint-plugin-router':
         specifier: 'catalog:'
         version: 1.161.6(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
@@ -575,7 +575,7 @@ importers:
         version: 3.5.3(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(zod@4.3.6)
       globals:
         specifier: 'catalog:'
-        version: 17.4.0
+        version: 17.5.0
       graphql-config:
         specifier: 'catalog:'
         version: 5.1.6(@types/node@24.12.2)(crossws@0.3.5)(graphql@16.11.0)(typescript@6.0.2)
@@ -612,7 +612,7 @@ importers:
         version: 19.2.14
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       dedent:
         specifier: 'catalog:'
         version: 1.7.2
@@ -673,7 +673,7 @@ importers:
         version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       eslint-vitest-rule-tester:
         specifier: 'catalog:'
         version: 3.1.0(@voidzero-dev/vite-plus-test@0.1.16(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.7(@types/node@24.12.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
@@ -707,7 +707,7 @@ importers:
         version: 1.3.12
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       bunup:
         specifier: 'catalog:'
         version: 0.16.31(typescript@6.0.2)
@@ -738,7 +738,7 @@ importers:
         version: 24.12.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       oxfmt:
         specifier: 'catalog:'
         version: 0.44.0
@@ -784,7 +784,7 @@ importers:
         version: 24.12.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       dedent:
         specifier: 'catalog:'
         version: 1.7.2
@@ -842,7 +842,7 @@ importers:
         version: 24.12.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       prettier:
         specifier: 'catalog:'
         version: 3.8.2
@@ -866,13 +866,13 @@ importers:
         version: 24.12.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       nolyfill:
         specifier: 'catalog:'
         version: 1.0.44
       renovate:
         specifier: 'catalog:'
-        version: 43.110.14(typanion@3.14.0)
+        version: 43.111.0(typanion@3.14.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -915,7 +915,7 @@ importers:
         version: 0.29.0(@voidzero-dev/vite-plus-test@0.1.16(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.7(@types/node@24.12.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(effect@3.21.0)
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260411.1
+        version: 7.0.0-dev.20260412.1
       publint:
         specifier: 'catalog:'
         version: 0.3.18
@@ -4300,8 +4300,8 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
-  '@tanstack/eslint-plugin-query@5.97.0':
-    resolution: {integrity: sha512-0/py2lxpUaCHKZeaOcTUVGHsbmr7719bh4ruj++HXgJQN8AtPvoPODyc8eOYTi/gZqr0LA2ZHH3ohSMrD3im+g==}
+  '@tanstack/eslint-plugin-query@5.99.0':
+    resolution: {integrity: sha512-jVp1AEL7S7BeuQvH5SN1F5UdrNW/AbryKDeWUUMeAKNzh9C+Ik/bRSa/HeuJLlmaN+WOUkdDFbtCK0go7BxnUQ==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ^5.4.0 || ^6.0.0
@@ -4585,43 +4585,43 @@ packages:
     resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260411.1':
-    resolution: {integrity: sha512-qdSDz0o4l4cEZhAn92ayzf7cKiMLrzSp9Xdk5mfaXpiahvxT39fNj5jiwDnRO+kHkHMMIYYL1nQbslSadargyg==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260412.1':
+    resolution: {integrity: sha512-sSkFG+hjtRWffg6FddF3dEkk7N3TRMEqfiUpixwcWhXgyocMdPw8wutTvQRBxQdgxeL9y01M2SO8A8YPPiEgVg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260411.1':
-    resolution: {integrity: sha512-2Nea85rMeBZe2UV6V8vBVJ3mSFHn4XZ+ceXGFpnfsU2nay0l1ncoYw91JA/yPwM5ui3+pxAYwl8PWLCxlZCB3Q==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260412.1':
+    resolution: {integrity: sha512-m2BTeaLkrHEEDg0D9snigddy01qTY+wgx+W+GpXAfx36PPvW4xWuGXNVWfSaB8bqAC9C8NeLnT/C9/G/rJ5v2w==}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260411.1':
-    resolution: {integrity: sha512-5QRz/eMIb1JtojvB0oeBbIc6ZNqZiiMUSRDsyp1qMJacdrs+1fbQ8MYFft5ceJe94mcolGHnbcozwPg8hf5fDg==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260412.1':
+    resolution: {integrity: sha512-JAdsG6MlVV1hoAUKPy8zxAL7xLeNxz8JgCbLCJVqW8EyH29R9FD4cFTqr7CSIRTNUEDzDTrgnXUyoRtDe1gr+w==}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260411.1':
-    resolution: {integrity: sha512-8/LqqQDp73kvT7aWh3sAFglGaSxtjxHIhEgqZ7XWG7+1aHHJeL1bcmRnk7JyP3BE5SPzs3bQhFC6Cvj6WQwTqQ==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260412.1':
+    resolution: {integrity: sha512-wDLekbfsfmKMWORg7CTnEnpKj8oXpU/6AEBrtVN9CEUCiQAe6yH878nZHhJNzWQXHtrtFf3lY49Yplqmdxja3w==}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260411.1':
-    resolution: {integrity: sha512-H5NWP+ot/L+Tn9ds4W/t4Xx/CuxZF4iHDdRx2hCr/O0l8pBBq8C/MBJ/eUgVZXO4lD+8J6eQ7nOlGtJ0SS8Sbg==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260412.1':
+    resolution: {integrity: sha512-gYgppiQIqid3jZ7D8THh4k3Q+4bwidrQH6SL9Xgbk1qfP6/jwv8twuPqDOfZ+cK2OD55lQHp15fOh2lMNAC40Q==}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260411.1':
-    resolution: {integrity: sha512-/Zc1rotE/NS72xNc4UjaEKCBanBsQ/0/fS2sYLcN9yd6p6AYFYzmTWfbGy5qvv1ckXOI0dkOolLzK8nYbrJzbA==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260412.1':
+    resolution: {integrity: sha512-TOh7rH5H3jisHJqRXJSjmUGMzcbNBocS/hufhXPQIv+g3pdG5IKZoSnv3SV62I5d12FFDSS5KQon5MQPnOKAHg==}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260411.1':
-    resolution: {integrity: sha512-PhFL0w2Uz9jKdTtm7uy2PPl3nJiacX24jxzDD0R0eBHOY/49L3V5iD7eyBACPSzyWp0/dD7pPdKSnRbS3nVRng==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260412.1':
+    resolution: {integrity: sha512-u+70wL89wspN1wKoX6FVNUATRGCG3BpleByP3H/UqOZvlwuMm8N7Gy8hEbM0U8bDyAuyP/daUfTBVkqXjjv9mA==}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260411.1':
-    resolution: {integrity: sha512-cBk+dPa5x5r9wnh5lz3zSnj7YJM1s/tSCf5owex+OkjJLji3iJu7J9kTH1SvvxA5kmkY76qFYw3vFN9h8W3gBA==}
+  '@typescript/native-preview@7.0.0-dev.20260412.1':
+    resolution: {integrity: sha512-tDw3XZt2BkjAlt/MJmnFGmbe9lgKmc5wezmrMoBIEvJcqz+/KVpVBVvjbkZoaiABnJmuG3G3b6IUFrEveTw6UQ==}
     hasBin: true
 
   '@vitest/eslint-plugin@1.6.15':
@@ -6107,8 +6107,8 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
-  globals@17.4.0:
-    resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
+  globals@17.5.0:
+    resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
     engines: {node: '>=18'}
 
   globby@11.1.0:
@@ -6520,8 +6520,8 @@ packages:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
 
-  knip@6.4.0:
-    resolution: {integrity: sha512-SAEeggehgkPdoLZWVEcFKzPw+vNlnrUBDqcX8cOcHGydRInSn5pnn9LN3dDJ8SkDHKXR7xYzNq3HtRJaYmxOHg==}
+  knip@6.4.1:
+    resolution: {integrity: sha512-Ry+ywmDFSZvKp/jx7LxMgsZWRTs931alV84e60lh0Stf6kSRYqSIUTkviyyDFRcSO3yY1Kpbi83OirN+4lA2Xw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -7604,8 +7604,8 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.0.0:
-    resolution: {integrity: sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==}
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
 
   protocols@2.0.2:
@@ -7749,8 +7749,8 @@ packages:
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
 
-  renovate@43.110.14:
-    resolution: {integrity: sha512-N0rU9MXLibRkIhhzXuFoFVMs5XhXfMCV0Ilkpv/fmX0lKS9ec65UjjtYyz9KGr9ZoUuCStJhpwIev2B3AIq0gQ==}
+  renovate@43.111.0:
+    resolution: {integrity: sha512-ByNcqJT6Dmv0SkOvxUQSZ2147Kljspt/jh3evcUIJuTFR7nQtMt7dKyGdJA6oav2fk7GTmAeKcmwsQeNfXS1tA==}
     engines: {node: ^24.11.0, pnpm: ^10.0.0}
     hasBin: true
 
@@ -12190,7 +12190,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/eslint-plugin-query@5.97.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)':
+  '@tanstack/eslint-plugin-query@5.99.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/utils': 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       eslint: 10.2.0(jiti@2.6.1)
@@ -12548,36 +12548,36 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260411.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260412.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260411.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260412.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260411.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260412.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260411.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260412.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260411.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260412.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260411.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260412.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260411.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260412.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260411.1':
+  '@typescript/native-preview@7.0.0-dev.20260412.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260411.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260411.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260411.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260411.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260411.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260411.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260411.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260412.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260412.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260412.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260412.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260412.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260412.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260412.1
 
   '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@voidzero-dev/vite-plus-test@0.1.16(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.7(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
@@ -13731,7 +13731,7 @@ snapshots:
       bytes: 3.1.2
       eslint: 10.2.0(jiti@2.6.1)
       functional-red-black-tree: 1.0.1
-      globals: 17.4.0
+      globals: 17.5.0
       jsx-ast-utils-x: 0.1.0
       lodash.merge: 4.6.2
       minimatch: 10.2.4
@@ -13782,7 +13782,7 @@ snapshots:
       core-js-compat: 3.49.0
       eslint: 10.2.0(jiti@2.6.1)
       find-up-simple: 1.0.1
-      globals: 17.4.0
+      globals: 17.5.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
       jsesc: 3.1.0
@@ -14201,7 +14201,7 @@ snapshots:
 
   globals@15.15.0: {}
 
-  globals@17.4.0: {}
+  globals@17.5.0: {}
 
   globby@11.1.0:
     dependencies:
@@ -14603,7 +14603,7 @@ snapshots:
 
   klona@2.0.6: {}
 
-  knip@6.4.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
+  knip@6.4.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       fast-glob: 3.3.3
@@ -15964,7 +15964,7 @@ snapshots:
       '@types/node': 24.12.2
       long: 5.3.2
 
-  protobufjs@8.0.0:
+  protobufjs@8.0.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -16161,7 +16161,7 @@ snapshots:
 
   remove-trailing-separator@1.1.0: {}
 
-  renovate@43.110.14(typanion@3.14.0):
+  renovate@43.111.0(typanion@3.14.0):
     dependencies:
       '@aws-sdk/client-codecommit': 3.1021.0
       '@aws-sdk/client-ec2': 3.1021.0
@@ -16256,7 +16256,7 @@ snapshots:
       p-throttle: 8.1.0
       parse-link-header: 2.0.0
       prettier: 3.8.1
-      protobufjs: 8.0.0
+      protobufjs: 8.0.1
       punycode: 2.3.1
       remark: 15.0.1
       remark-gfm: 4.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ catalog:
   '@prettier/plugin-oxc': 0.1.3
   '@prettier/plugin-xml': 3.4.2
   '@stylistic/eslint-plugin': 5.10.0
-  '@tanstack/eslint-plugin-query': 5.97.0
+  '@tanstack/eslint-plugin-query': 5.99.0
   '@tanstack/eslint-plugin-router': 1.161.6
   '@types/bun': 1.3.12
   '@types/node': 24.12.2
@@ -36,7 +36,7 @@ catalog:
   '@typescript-eslint/scope-manager': 8.58.1
   '@typescript-eslint/utils': 8.58.1
   '@vitest/eslint-plugin': 1.6.15
-  '@typescript/native-preview': 7.0.0-dev.20260411.1
+  '@typescript/native-preview': 7.0.0-dev.20260412.1
   bunup: 0.16.31
   dedent: 1.7.2
   defu: 6.1.7
@@ -68,10 +68,10 @@ catalog:
   eslint-plugin-zod: 3.5.3
   eslint-typegen: 2.3.1
   eslint-vitest-rule-tester: 3.1.0
-  globals: 17.4.0
+  globals: 17.5.0
   graphql-config: 5.1.6
   jsonc-eslint-parser: 3.1.0
-  knip: 6.4.0
+  knip: 6.4.1
   local-pkg: 1.1.2
   nolyfill: 1.0.44
   nypm: 0.6.5
@@ -85,7 +85,7 @@ catalog:
   prettier-plugin-tailwindcss: 0.7.2
   publint: 0.3.18
   react: 19.2.5
-  renovate: 43.110.14
+  renovate: 43.111.0
   tailwind-csstree: 0.3.1
   tinyexec: 1.1.1
   tinyglobby: 0.2.16

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -6,6 +6,11 @@
       "sourceType": "github",
       "computedHash": "f381323f26079d273693f9f8ec9a85a64cace1f59d3ccff2367eaa8f579a186f"
     },
+    "tsdown-migrate": {
+      "source": "rolldown/tsdown",
+      "sourceType": "github",
+      "computedHash": "db33424dfc3f9de5e5056a4592d91a742d63d4d189c962380228cd576dde04c3"
+    },
     "turborepo": {
       "source": "vercel/turborepo",
       "sourceType": "github",


### PR DESCRIPTION
This pull request adds a new AI agent skill for migrating TypeScript library projects from tsup to tsdown. The skill provides comprehensive migration guidance including:

- Complete option mappings between tsup and tsdown configurations
- Config file transformation rules (renaming files, updating imports, property changes)
- Default value differences that need explicit handling during migration
- Package.json updates for dependencies, scripts, and config fields
- Identification of unsupported options and their alternatives
- Documentation of new tsdown-exclusive features to suggest post-migration

The skill includes detailed reference guides covering option mappings, package.json changes, and architectural differences between the two bundlers. It also updates ESLint plugin dependencies and Renovate to their latest versions.