### PR TITLE
Update dependencies: posthog-node to 5.30.1, prettier-plugin-tailwindcss to 0.7.3, typescript native preview, and rename PostHog env vars to POSTHOG_OPENCODE_* prefix

### DIFF
--- a/.changeset/clean-mice-unite.md
+++ b/.changeset/clean-mice-unite.md
@@ -1,0 +1,5 @@
+---
+'@2digits/prettier-config': patch
+---
+
+Update prettier-plugin-tailwindcss to 0.7.3

--- a/.changeset/good-monkeys-sneeze.md
+++ b/.changeset/good-monkeys-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@2digits/opencode-plugin': patch
+---
+
+Update posthog-node to 5.30.1

--- a/packages/opencode-plugin/test/config.spec.ts
+++ b/packages/opencode-plugin/test/config.spec.ts
@@ -4,14 +4,14 @@ import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { buildConfig } from '../src/config.js';
 
 const ENV_KEYS = [
-  'POSTHOG_API_KEY',
-  'POSTHOG_HOST',
+  'POSTHOG_OPENCODE_API_KEY',
+  'POSTHOG_OPENCODE_HOST',
   'POSTHOG_OPENCODE_ENABLED',
-  'POSTHOG_LLMA_PRIVACY_MODE',
-  'POSTHOG_LLMA_TRACE_GROUPING',
-  'POSTHOG_LLMA_SESSION_WINDOW_MINUTES',
-  'POSTHOG_MAX_ATTRIBUTE_LENGTH',
-  'POSTHOG_LLMA_DISTINCT_ID',
+  'POSTHOG_OPENCODE_LLMA_PRIVACY_MODE',
+  'POSTHOG_OPENCODE_LLMA_TRACE_GROUPING',
+  'POSTHOG_OPENCODE_LLMA_SESSION_WINDOW_MINUTES',
+  'POSTHOG_OPENCODE_MAX_ATTRIBUTE_LENGTH',
+  'POSTHOG_OPENCODE_LLMA_DISTINCT_ID',
   'POSTHOG_LLMA_CUSTOM_PROPERTIES',
 ] as const;
 
@@ -36,13 +36,13 @@ function createCtx(gitEmail: string) {
 
 describe(buildConfig, () => {
   it('builds config from env and git email', async () => {
-    process.env.POSTHOG_API_KEY = 'key';
+    process.env.POSTHOG_OPENCODE_API_KEY = 'key';
     process.env.POSTHOG_OPENCODE_ENABLED = 'true';
-    process.env.POSTHOG_LLMA_PRIVACY_MODE = 'true';
-    process.env.POSTHOG_LLMA_TRACE_GROUPING = 'session';
-    process.env.POSTHOG_LLMA_SESSION_WINDOW_MINUTES = '30';
-    process.env.POSTHOG_MAX_ATTRIBUTE_LENGTH = '500';
-    process.env.POSTHOG_LLMA_DISTINCT_ID = 'custom-id';
+    process.env.POSTHOG_OPENCODE_LLMA_PRIVACY_MODE = 'true';
+    process.env.POSTHOG_OPENCODE_LLMA_TRACE_GROUPING = 'session';
+    process.env.POSTHOG_OPENCODE_LLMA_SESSION_WINDOW_MINUTES = '30';
+    process.env.POSTHOG_OPENCODE_MAX_ATTRIBUTE_LENGTH = '500';
+    process.env.POSTHOG_OPENCODE_LLMA_DISTINCT_ID = 'custom-id';
     process.env.POSTHOG_LLMA_CUSTOM_PROPERTIES = '{"team":"core"}';
 
     const config = await buildConfig(createCtx('user@example.com\n'));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ catalogs:
       specifier: 8.59.0
       version: 8.59.0
     '@typescript/native-preview':
-      specifier: 7.0.0-dev.20260423.1
-      version: 7.0.0-dev.20260423.1
+      specifier: 7.0.0-dev.20260424.1
+      version: 7.0.0-dev.20260424.1
     '@vitest/eslint-plugin':
       specifier: 1.6.16
       version: 1.6.16
@@ -241,8 +241,8 @@ catalogs:
       specifier: 2.3.0
       version: 2.3.0
     posthog-node:
-      specifier: 5.30.0
-      version: 5.30.0
+      specifier: 5.30.1
+      version: 5.30.1
     prettier:
       specifier: 3.8.3
       version: 3.8.3
@@ -250,8 +250,8 @@ catalogs:
       specifier: 1.8.0
       version: 1.8.0
     prettier-plugin-tailwindcss:
-      specifier: 0.7.2
-      version: 0.7.2
+      specifier: 0.7.3
+      version: 0.7.3
     publint:
       specifier: 0.3.18
       version: 0.3.18
@@ -413,7 +413,7 @@ importers:
         version: 0.29.0(@voidzero-dev/vite-plus-test@0.1.19(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(effect@3.21.2)
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       publint:
         specifier: 'catalog:'
         version: 0.3.18
@@ -443,7 +443,7 @@ importers:
         version: 0.18.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       publint:
         specifier: 'catalog:'
         version: 0.3.18
@@ -615,7 +615,7 @@ importers:
         version: 19.2.14
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       dedent:
         specifier: 'catalog:'
         version: 1.7.2
@@ -676,7 +676,7 @@ importers:
         version: 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       eslint-vitest-rule-tester:
         specifier: 'catalog:'
         version: 3.1.0(@voidzero-dev/vite-plus-test@0.1.19(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
@@ -700,7 +700,7 @@ importers:
         version: 1.14.22
       posthog-node:
         specifier: 'catalog:'
-        version: 5.30.0
+        version: 5.30.1
     devDependencies:
       '@2digits/tsconfig':
         specifier: workspace:*
@@ -710,7 +710,7 @@ importers:
         version: 1.3.13
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       bunup:
         specifier: 'catalog:'
         version: 0.16.31(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@6.0.3)
@@ -747,7 +747,7 @@ importers:
         version: 24.12.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       oxfmt:
         specifier: 'catalog:'
         version: 0.46.0
@@ -793,7 +793,7 @@ importers:
         version: 24.12.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       dedent:
         specifier: 'catalog:'
         version: 1.7.2
@@ -838,7 +838,7 @@ importers:
         version: 1.8.0(prettier@3.8.3)
       prettier-plugin-tailwindcss:
         specifier: 'catalog:'
-        version: 0.7.2(@ianvs/prettier-plugin-sort-imports@4.7.1(@prettier/plugin-oxc@0.1.4)(prettier@3.8.3))(@prettier/plugin-oxc@0.1.4)(prettier-plugin-jsdoc@1.8.0(prettier@3.8.3))(prettier@3.8.3)
+        version: 0.7.3(@ianvs/prettier-plugin-sort-imports@4.7.1(@prettier/plugin-oxc@0.1.4)(prettier@3.8.3))(@prettier/plugin-oxc@0.1.4)(prettier-plugin-jsdoc@1.8.0(prettier@3.8.3))(prettier@3.8.3)
     devDependencies:
       '@2digits/tsconfig':
         specifier: workspace:*
@@ -851,7 +851,7 @@ importers:
         version: 24.12.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -875,7 +875,7 @@ importers:
         version: 24.12.2
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       nolyfill:
         specifier: 'catalog:'
         version: 1.0.44
@@ -924,7 +924,7 @@ importers:
         version: 0.29.0(@voidzero-dev/vite-plus-test@0.1.19(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(effect@3.21.2)
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260424.1
       publint:
         specifier: 'catalog:'
         version: 0.3.18
@@ -3901,11 +3901,11 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@posthog/core@1.27.1':
-    resolution: {integrity: sha512-130F5zAmGoY0KAqdT2FYfU79mk54z0wTWfCMkyzXmkKz2eg23694O2ofaAf4NuIdI8e6LFNHyaZ7aWbatUeW5A==}
+  '@posthog/core@1.27.2':
+    resolution: {integrity: sha512-y4YzMnUPbuVmL9s31JnJ2lTXxqy1QBTttxzjtfAuogQCN7nGpeDJoVAFz48CMFfLVFexLC2zt7LnkVWfq2hrxw==}
 
-  '@posthog/types@1.371.2':
-    resolution: {integrity: sha512-Ak3kuGMPBTjuoK6Ki0kQbq9eROk7LRJ3GBkbQINCZBT9FPlHvlXRwQr0/OVsi4xYPSMSGxWjRDMPFsR9Px66Cg==}
+  '@posthog/types@1.371.3':
+    resolution: {integrity: sha512-oRmCJUMTM43tgbiH8fgGTu5ksjN5d6Lc6ckEYGUpbEMUVB+Of/yIOjb7Okaaqw0erSvtQumFM0teEP+nUI3JtQ==}
 
   '@prettier/plugin-oxc@0.1.4':
     resolution: {integrity: sha512-P/KX37tuR1R7xMHMakgzdWsRDMeze7SkwUcGQKbqQVSsJLW0q5kxax2dxEJgK4E4zIoMy7pG6UUE7x4al8AQeg==}
@@ -4684,50 +4684,50 @@ packages:
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-wbLr6o5fROaCYt6cOpFhbe92FJAOdhAHwm/s8I/IyN5HbL1ULgel/wHaZiR+ws+27rgruNUiCENzTUg9vSz2bA==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260424.1':
+    resolution: {integrity: sha512-cDlRsCddHfTB++G1jFFO13y+4WkGn5RVF5yHFjFEQ9tvhN9FUxFx+0BxWIFoGg17Lp6/55kGkBD75qlNLdNzwA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-13MpNT+4MgkgrfiW2u03rnER5aB3yz9fA0bWEYh6IH3rIqA2AR3Dntp3QXW4sQrZf0SriXqHe2R7X3HCT5xmqA==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260424.1':
+    resolution: {integrity: sha512-vnMTeBlKq0OvRVzp2j9cliNNJ3ReI3mn8UihTJ5cAw7dMPH+uRfZP+TrpRBFKZJMVTteILuZS9XopUmHk/M++g==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-ICIkJDTqmn0R4Vs811+Ht2RYTk1OCrAhHCu0JthmhR216T1Tqgi5DWRoCprp3RL1qU6fLnxxrIpEbNlNN7XFYA==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260424.1':
+    resolution: {integrity: sha512-JRJAi8dCvHEn280XxwhJi4aDFwIHrwQVhsSztpGodcqFEXMJ9WZlbR9Q8pWmJnPeFFFdTMPgSs5yzF4ZBQymBQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-CxUA15qbPQRvz2nanBpiv1h4tgXTCJJwqOtgKMSdIuPkow8dyYW3ba5oLoH/jZhS4792XislX659hlFrfiU6CQ==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260424.1':
+    resolution: {integrity: sha512-gojRlfaxqbXnWKdyuKoKj9wACY3Y6h/kdhXG/QRpLgp/K/9pwkj4AJ6zVCkqvyEULc8ESwPygiMrJHlzRXXSvg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-cWLFS4R8dOU1YuUJ/2VLeGMVIjgI3GGb/f9rRY5MbWHq5l3NNZh8y1QwAOrTh3+g3q6+znArfxVnD2hZHUz8Mw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260424.1':
+    resolution: {integrity: sha512-K34ZcseVSpysIhlyF1ors76apV3wleoRhS1dM8gMoYubl2vJ8eA0y6O8YzQuzt0lLkByBwk2Ikj02DwHD7Lx0Q==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-OWaGUI4+dHqYZv+k6sITx9Y27FNy3XzNFk4OrOiYtBkIO/xrb9TPMP4A5XI4n5zwRLIv3xne9g039xgRbaeyoQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260424.1':
+    resolution: {integrity: sha512-tNWQjHbdawI+6KBeaVcgU/QIu4PJ2IfW/cGGvv/N+1o6No9MxcU1HO0n2Kse6zjm3xRPNrVG/FG0q/viMFxByg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-5MQjO/qdLwXpjW7Dy/1lNv7Vtpvo6bhCkbjan4PoRN5/eeyqEqDWxdf8AGE4btLmHqyIjEHRuYf7kp2tlAr6lQ==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260424.1':
+    resolution: {integrity: sha512-kfvSYfsXKxNVzcmWudyPqJhjTcolsejDEk9hpUQvO8O6nHnE3gXeH7e1NiE/1xS52567ZQNvhSbc2vfkciC+bA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-9WD7TJJlGvt9PQqJI/+44dVP4oqGQFIkYrpXt7nlQ0WgNIErN52x/XhxmJ4nWft06qejgPiUbPo4aYRNOmIHXg==}
+  '@typescript/native-preview@7.0.0-dev.20260424.1':
+    resolution: {integrity: sha512-AExG+RjPYS/YD4n4y4B3qznONzpARzSYpZBYayXLgfDV+mIRLIFk7KWxuO9wi2Dx4zYV/W+YmM19AiP4WeTUaA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -7623,8 +7623,8 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-node@5.30.0:
-    resolution: {integrity: sha512-/5X7IbC5q4a6Igql2D44ztotGaRqVaIEMIh/laNaTzmL4WY1jEpo7wQRLbw45gzcPH/hfkYImwvi9A9vt/DyxA==}
+  posthog-node@5.30.1:
+    resolution: {integrity: sha512-eAmKDGgA4Au7JBgwgftExDgSLjF6KO8RWBntAM50hNuNHGNF9MSko0M+0HTQUg27dLzmg5DIjwyJVOFDAWBFsw==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       rxjs: ^7.0.0
@@ -7648,8 +7648,8 @@ packages:
     peerDependencies:
       prettier: ^3.0.0
 
-  prettier-plugin-tailwindcss@0.7.2:
-    resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
+  prettier-plugin-tailwindcss@0.7.3:
+    resolution: {integrity: sha512-lckXaWWdo2ZVXoMoUO3WIBiz9hVY+YBEh1gYyMFfrWP9WZW/wpFXQKizHx7WrFQFMkcG0bGShdpp531X1n+qpg==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -11852,11 +11852,11 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@posthog/core@1.27.1':
+  '@posthog/core@1.27.2':
     dependencies:
-      '@posthog/types': 1.371.2
+      '@posthog/types': 1.371.3
 
-  '@posthog/types@1.371.2': {}
+  '@posthog/types@1.371.3': {}
 
   '@prettier/plugin-oxc@0.1.4':
     dependencies:
@@ -12789,36 +12789,36 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260424.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260424.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260424.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260424.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260424.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260424.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260424.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260423.1':
+  '@typescript/native-preview@7.0.0-dev.20260424.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260423.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260424.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260424.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260424.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260424.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260424.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260424.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260424.1
 
   '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(@voidzero-dev/vite-plus-test@0.1.19(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
@@ -16155,9 +16155,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-node@5.30.0:
+  posthog-node@5.30.1:
     dependencies:
-      '@posthog/core': 1.27.1
+      '@posthog/core': 1.27.2
 
   prebuild-install@7.1.3:
     dependencies:
@@ -16186,7 +16186,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  prettier-plugin-tailwindcss@0.7.2(@ianvs/prettier-plugin-sort-imports@4.7.1(@prettier/plugin-oxc@0.1.4)(prettier@3.8.3))(@prettier/plugin-oxc@0.1.4)(prettier-plugin-jsdoc@1.8.0(prettier@3.8.3))(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.7.3(@ianvs/prettier-plugin-sort-imports@4.7.1(@prettier/plugin-oxc@0.1.4)(prettier@3.8.3))(@prettier/plugin-oxc@0.1.4)(prettier-plugin-jsdoc@1.8.0(prettier@3.8.3))(prettier@3.8.3):
     dependencies:
       prettier: 3.8.3
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalog:
   '@typescript-eslint/scope-manager': 8.59.0
   '@typescript-eslint/utils': 8.59.0
   '@vitest/eslint-plugin': 1.6.16
-  '@typescript/native-preview': 7.0.0-dev.20260423.1
+  '@typescript/native-preview': 7.0.0-dev.20260424.1
   bunup: 0.16.31
   dedent: 1.7.2
   defu: 6.1.7
@@ -80,10 +80,10 @@ catalog:
   oxlint-tsgolint: 0.21.1
   pkg-pr-new: 0.0.66
   pkg-types: 2.3.0
-  posthog-node: 5.30.0
+  posthog-node: 5.30.1
   prettier: 3.8.3
   prettier-plugin-jsdoc: 1.8.0
-  prettier-plugin-tailwindcss: 0.7.2
+  prettier-plugin-tailwindcss: 0.7.3
   publint: 0.3.18
   react: 19.2.5
   renovate: 43.139.6


### PR DESCRIPTION
## Dependency Updates & Environment Variable Renaming

### PostHog Environment Variable Namespace

Environment variables used to configure the opencode PostHog integration have been renamed to include the `OPENCODE` namespace prefix, making them more specific and avoiding potential conflicts:

| Before | After |
|---|---|
| `POSTHOG_API_KEY` | `POSTHOG_OPENCODE_API_KEY` |
| `POSTHOG_HOST` | `POSTHOG_OPENCODE_HOST` |
| `POSTHOG_LLMA_PRIVACY_MODE` | `POSTHOG_OPENCODE_LLMA_PRIVACY_MODE` |
| `POSTHOG_LLMA_TRACE_GROUPING` | `POSTHOG_OPENCODE_LLMA_TRACE_GROUPING` |
| `POSTHOG_LLMA_SESSION_WINDOW_MINUTES` | `POSTHOG_OPENCODE_LLMA_SESSION_WINDOW_MINUTES` |
| `POSTHOG_MAX_ATTRIBUTE_LENGTH` | `POSTHOG_OPENCODE_MAX_ATTRIBUTE_LENGTH` |
| `POSTHOG_LLMA_DISTINCT_ID` | `POSTHOG_OPENCODE_LLMA_DISTINCT_ID` |

### Package Updates

- `posthog-node` → `5.30.1`
- `prettier-plugin-tailwindcss` → `0.7.3`
- `@typescript/native-preview` → `7.0.0-dev.20260424.1`