### PR TITLE
Fix PostHog LLM trace capture with immediate snapshots, input/output state, and cost properties

### DIFF
--- a/.changeset/every-frogs-grow.md
+++ b/.changeset/every-frogs-grow.md
@@ -1,0 +1,9 @@
+---
+'@2digits/opencode-plugin': patch
+---
+
+Fix PostHog LLM trace capture
+
+- Sent `$ai_trace` snapshots immediately when assistant generations complete
+- Added trace input, output, and cost properties for PostHog trace summaries
+- Avoided duplicate trace snapshots when trace state has not changed

--- a/packages/opencode-plugin/src/capture.ts
+++ b/packages/opencode-plugin/src/capture.ts
@@ -22,8 +22,15 @@ export function buildTraceProperties(config: Config, traceState: TraceState, lat
     $ai_trace_id: traceState.traceID,
     $ai_session_id: traceState.sessionID,
     $ai_latency: latency,
+    $ai_input_state: config.privacyMode
+      ? undefined
+      : serializeAttribute(traceState.inputState, config.maxAttributeLength),
+    $ai_output_state: config.privacyMode
+      ? undefined
+      : serializeAttribute(traceState.outputState, config.maxAttributeLength),
     $ai_total_input_tokens: traceState.totalInputTokens,
     $ai_total_output_tokens: traceState.totalOutputTokens,
+    $ai_total_cost_usd: traceState.totalCostUsd,
     $ai_is_error: traceState.hasError,
     $ai_error: traceState.errorMessage,
     $ai_span_name: traceState.traceName,
@@ -146,6 +153,24 @@ export function createCaptureManager(config: Config) {
     });
   }
 
+  async function captureImmediate(
+    event: string,
+    sessionID: string,
+    properties: Record<string, unknown>,
+  ): Promise<void> {
+    const posthog = ensureClient();
+
+    if (!posthog) {
+      return;
+    }
+
+    await posthog.captureImmediate({
+      distinctId: getDistinctId(config, sessionID),
+      event,
+      properties,
+    });
+  }
+
   async function shutdown(): Promise<void> {
     if (!client) {
       return;
@@ -174,6 +199,7 @@ export function createCaptureManager(config: Config) {
 
   return {
     capture,
+    captureImmediate,
     registerShutdown,
     shutdown,
   };

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -27,22 +27,35 @@ const plugin: Plugin = async (ctx) => {
   const state = createSessionState(config);
   const capture = createCaptureManager(config);
 
-  function flushTrace(sessionID: string) {
+  async function captureTrace(traceState: NonNullable<ReturnType<typeof state.getTraceState>>): Promise<void> {
+    if (traceState.lastTraceCapturedAt === traceState.lastActivityAt) {
+      return;
+    }
+
+    const latency = Math.max(0, traceState.lastActivityAt - traceState.startedAt) / 1000;
+
+    await capture.captureImmediate(
+      '$ai_trace',
+      traceState.sessionID,
+      buildTraceProperties(config, traceState, latency),
+    );
+    traceState.lastTraceCapturedAt = traceState.lastActivityAt;
+  }
+
+  async function flushTrace(sessionID: string) {
     const traceState = state.getTraceState(sessionID);
 
     if (!traceState) {
       return;
     }
 
-    const latency = Math.max(0, traceState.lastActivityAt - traceState.startedAt) / 1000;
-
-    capture.capture('$ai_trace', traceState.sessionID, buildTraceProperties(config, traceState, latency));
+    await captureTrace(traceState);
     state.clearSessionState(sessionID);
   }
 
   async function shutdown(): Promise<void> {
     for (const sessionID of state.getTraceSessionIDs()) {
-      flushTrace(sessionID);
+      await flushTrace(sessionID);
     }
 
     await capture.shutdown();
@@ -50,7 +63,7 @@ const plugin: Plugin = async (ctx) => {
 
   capture.registerShutdown(shutdown);
 
-  function completeAssistantMessage(info: CompletedAssistantMessageInfo) {
+  async function completeAssistantMessage(info: CompletedAssistantMessageInfo) {
     const resolved = state.getOrCreateGenerationState(info);
 
     if (!resolved) {
@@ -58,6 +71,7 @@ const plugin: Plugin = async (ctx) => {
     }
 
     const { generation, pending, traceState } = resolved;
+    const output = state.getAssistantOutputForMessage(info.id);
     const errorMessage = state.updateTraceStateFromAssistantMessage(traceState, pending, {
       mode: info.mode,
       time: { completed: info.time.completed },
@@ -66,6 +80,7 @@ const plugin: Plugin = async (ctx) => {
         input: info.tokens.input,
         output: info.tokens.output,
       },
+      output,
       error: info.error,
     });
     const { toolsCalled, toolCallCount } = state.getGenerationToolProperties(generation.spanID);
@@ -80,11 +95,12 @@ const plugin: Plugin = async (ctx) => {
         traceState,
         info,
         errorMessage,
-        output: state.getAssistantOutputForMessage(info.id),
+        output,
         toolsCalled,
         toolCallCount,
       }),
     );
+    await captureTrace(traceState);
 
     state.cleanupAssistantMessage(info.id, generation.spanID);
   }
@@ -101,7 +117,7 @@ const plugin: Plugin = async (ctx) => {
     }
 
     if (event.type === 'session.deleted') {
-      flushTrace(event.properties.info.id);
+      await flushTrace(event.properties.info.id);
 
       return;
     }
@@ -130,7 +146,7 @@ const plugin: Plugin = async (ctx) => {
 
     if (state.shouldCompleteAssistantMessage(info)) {
       state.markAssistantMessageCompleted(info.id);
-      completeAssistantMessage(info);
+      await completeAssistantMessage(info);
     }
 
     if (false as boolean) {
@@ -145,7 +161,7 @@ const plugin: Plugin = async (ctx) => {
       const sessionWindowMs = config.sessionWindowMinutes * 60_000;
 
       if (existingTrace && config.traceGrouping === 'message') {
-        flushTrace(input.sessionID);
+        await flushTrace(input.sessionID);
       }
 
       if (
@@ -153,7 +169,7 @@ const plugin: Plugin = async (ctx) => {
         config.traceGrouping === 'session' &&
         startedAt - existingTrace.lastActivityAt >= sessionWindowMs
       ) {
-        flushTrace(input.sessionID);
+        await flushTrace(input.sessionID);
       }
 
       state.beginPrompt(input, output);

--- a/packages/opencode-plugin/src/state.ts
+++ b/packages/opencode-plugin/src/state.ts
@@ -78,7 +78,10 @@ export function createSessionState(config: Config) {
       agentName: agentName ?? config.projectName,
       errorMessage: undefined,
       hasError: false,
+      inputState: undefined,
       lastActivityAt: startedAt,
+      lastTraceCapturedAt: undefined,
+      outputState: undefined,
       sessionID,
       startedAt,
       totalCostUsd: 0,
@@ -112,6 +115,7 @@ export function createSessionState(config: Config) {
       userMessageID: output.message.id,
     };
 
+    traceState.inputState ??= prompt;
     traceState.traceName ??= getTraceName(prompt);
 
     pendingMessages.set(getPendingKey(input.sessionID, output.message.id), pending);
@@ -203,6 +207,7 @@ export function createSessionState(config: Config) {
       time: { completed: number };
       cost: number;
       tokens: { input: number; output: number };
+      output?: string;
       error?: unknown;
     },
   ): string | undefined {
@@ -213,6 +218,8 @@ export function createSessionState(config: Config) {
     traceState.totalOutputTokens += info.tokens.output;
 
     const errorMessage = getErrorMessage(info.error);
+
+    traceState.outputState = info.output ?? errorMessage ?? traceState.outputState;
 
     if (errorMessage) {
       traceState.hasError = true;

--- a/packages/opencode-plugin/src/types.ts
+++ b/packages/opencode-plugin/src/types.ts
@@ -28,7 +28,10 @@ export interface TraceState {
   agentName: string;
   errorMessage?: string;
   hasError: boolean;
+  inputState?: string;
   lastActivityAt: number;
+  lastTraceCapturedAt?: number;
+  outputState?: string;
   sessionID: string;
   startedAt: number;
   totalCostUsd: number;

--- a/packages/opencode-plugin/test/capture.spec.ts
+++ b/packages/opencode-plugin/test/capture.spec.ts
@@ -18,7 +18,9 @@ const config: Config = {
 const traceState: TraceState = {
   agentName: 'build',
   hasError: false,
+  inputState: 'hello',
   lastActivityAt: 20,
+  outputState: 'done',
   sessionID: 'session-1',
   startedAt: 10,
   totalCostUsd: 2,
@@ -34,6 +36,9 @@ describe('property builders', () => {
       $ai_trace_id: 'trace-1',
       $ai_session_id: 'session-1',
       $ai_latency: 12,
+      $ai_input_state: 'hello',
+      $ai_output_state: 'done',
+      $ai_total_cost_usd: 2,
       $ai_agent_name: 'build',
       env: 'test',
     });


### PR DESCRIPTION
## Fix PostHog LLM Trace Capture

Resolves several issues with how `$ai_trace` events are captured and reported to PostHog.

### Changes

**Immediate trace capture on generation completion**
Previously, `$ai_trace` snapshots were only sent when a session was deleted or a new prompt began. Traces are now also sent immediately via `captureImmediate` each time an assistant generation completes, ensuring PostHog receives up-to-date trace data without waiting for session teardown.

**Deduplication of trace snapshots**
A `lastTraceCapturedAt` timestamp is tracked on `TraceState`. Before sending a snapshot, the plugin checks whether the trace state has changed since the last capture and skips sending if it has not, preventing redundant duplicate events.

**Trace input, output, and cost properties**
Three new properties are now included in `$ai_trace` events:
- `$ai_input_state` — the first prompt sent in the trace (omitted in privacy mode)
- `$ai_output_state` — the most recent assistant output or error message (omitted in privacy mode)
- `$ai_total_cost_usd` — the accumulated cost across all generations in the trace