### PR TITLE
chore(prettier-config): add npm support metadata

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -10,6 +10,10 @@
     "url": "git+https://github.com/2digits-agency/configs.git",
     "directory": "packages/prettier-config"
   },
+  "homepage": "https://github.com/2digits-agency/configs/tree/main/packages/prettier-config",
+  "bugs": {
+    "url": "https://github.com/2digits-agency/configs/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Summary

- Add npm homepage metadata for the @2digits/prettier-config package subdirectory.
- Add npm bugs.url metadata pointing to the repository issue tracker.
- Leave runtime code, dependencies, package files, and version unchanged.

Verification

- Parsed packages/prettier-config/package.json with Node and confirmed homepage and bugs.url.
- npm pack --dry-run --ignore-scripts --json from packages/prettier-config.
- git diff --check