### PR TITLE
chore(eslint-config): add npm bugs metadata

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,6 +12,9 @@
     "url": "git+https://github.com/2digits-agency/configs.git",
     "directory": "packages/eslint-config"
   },
+  "bugs": {
+    "url": "https://github.com/2digits-agency/configs/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Summary

- Add npm bugs.url metadata for @2digits/eslint-config.
- Leave runtime code, dependencies, package files, and version unchanged.

Verification

- Parsed packages/eslint-config/package.json with Node and confirmed bugs.url.
- npm pack --dry-run --ignore-scripts --json from packages/eslint-config.
- git diff --check