### PR TITLE
chore: add npm bugs and homepage metadata to prettier-config and eslint-config

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -108,4 +108,8 @@
     "node": "24.16.0"
   },
   "public": true
+,
+  "bugs": {
+    "url": "https://github.com/2digits-agency/configs/issues"
+  }
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -53,4 +53,9 @@
     "prettier": "catalog:"
   },
   "public": true
+,
+  "homepage": "https://github.com/2digits-agency/configs/tree/main/packages/prettier-config#readme",
+  "bugs": {
+    "url": "https://github.com/2digits-agency/configs/issues"
+  }
 }


### PR DESCRIPTION
Two published packages are missing npm support metadata:

- **`@2digits/prettier-config`**: missing `bugs` and `homepage`
- **`@2digits/eslint-config`**: missing `bugs`

This adds the missing fields pointing to the GitHub repository and issue tracker.

No runtime code, dependencies, or tests changed.