### PR TITLE
Upgrade eslint-plugin-tailwindcss to v4.2.0 for Tailwind CSS v4

### DIFF
--- a/.tegami/2026-07-22-6b4049ad.md
+++ b/.tegami/2026-07-22-6b4049ad.md
@@ -1,0 +1,8 @@
+---
+packages:
+  '@2digits/eslint-config': minor
+---
+
+## Upgrade eslint-plugin-tailwindcss to v4.2.0
+
+Supports Tailwind CSS v4 with the rewritten plugin. Settings now use `cssConfigPath` (CSS entry) and `functions` instead of the v3 `config`/`callees` options. Auto-enables only when Tailwind CSS v4+ is installed.

--- a/packages/eslint-config/fixtures/input/styles.css
+++ b/packages/eslint-config/fixtures/input/styles.css
@@ -1,3 +1,5 @@
+@import 'tailwindcss';
+
 .container {
   display: flex;
   flex-direction: column;
@@ -31,10 +33,6 @@
   }
 }
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 .card {
-  @apply p-4 rounded-lg shadow-md;
+  @apply rounded-lg p-4 shadow-md;
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -97,6 +97,7 @@
     "eslint-typegen": "catalog:",
     "publint": "catalog:",
     "react": "catalog:",
+    "tailwindcss": "catalog:",
     "tinyexec": "catalog:",
     "tinyglobby": "catalog:",
     "typescript": "catalog:",
@@ -105,7 +106,13 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "eslint": "catalog:"
+    "eslint": "catalog:",
+    "tailwindcss": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "24.18.0"

--- a/packages/eslint-config/src/configs/tailwind.ts
+++ b/packages/eslint-config/src/configs/tailwind.ts
@@ -2,11 +2,37 @@ import * as findUp from 'empathic/find';
 import { findWorkspaceDir } from 'pkg-types';
 
 import { GLOB_SRC } from '../globs';
-import type { OptionsOverrides, TypedFlatConfigItem } from '../types';
+import type { OptionsTailwind, TypedFlatConfigItem } from '../types';
 import { interopDefault } from '../utils';
 
-export async function tailwind(options: OptionsOverrides = {}): Promise<Array<TypedFlatConfigItem>> {
-  const { overrides = {} } = options;
+const CSS_CONFIG_CANDIDATES = [
+  'src/styles.css',
+  'src/style.css',
+  'src/globals.css',
+  'src/index.css',
+  'src/app.css',
+  'src/tailwind.css',
+  'app/globals.css',
+  'styles/globals.css',
+  'styles/tailwind.css',
+  'styles.css',
+  'globals.css',
+] as const;
+
+function findCssConfigPath(last?: string): string | undefined {
+  for (const candidate of CSS_CONFIG_CANDIDATES) {
+    const found = findUp.file(candidate, { last });
+
+    if (found) {
+      return found;
+    }
+  }
+
+  return undefined;
+}
+
+export async function tailwind(options: OptionsTailwind = {}): Promise<Array<TypedFlatConfigItem>> {
+  const { overrides = {}, cssConfigPath: cssConfigPathOption } = options;
 
   const [tailwindcss, { tailwindFunctions }, last] = await Promise.all([
     interopDefault(import('eslint-plugin-tailwindcss')),
@@ -14,7 +40,7 @@ export async function tailwind(options: OptionsOverrides = {}): Promise<Array<Ty
     findWorkspaceDir().catch(() => undefined),
   ]);
 
-  const config = findUp.file('tailwind.config.ts', { last }) ?? findUp.file('tailwind.config.js', { last });
+  const cssConfigPath = cssConfigPathOption ?? findCssConfigPath(last);
 
   return [
     {
@@ -25,8 +51,8 @@ export async function tailwind(options: OptionsOverrides = {}): Promise<Array<Ty
       },
       settings: {
         tailwindcss: {
-          callees: tailwindFunctions,
-          config,
+          functions: tailwindFunctions,
+          ...(cssConfigPath ? { cssConfigPath } : {}),
         },
       },
       rules: {

--- a/packages/eslint-config/src/factory.ts
+++ b/packages/eslint-config/src/factory.ts
@@ -1,6 +1,6 @@
 // oxlint-disable complexity
 import { FlatConfigComposer } from 'eslint-flat-config-utils';
-import { isPackageExists } from 'local-pkg';
+import { getPackageInfoSync, isPackageExists } from 'local-pkg';
 import { findWorkspaceDir } from 'pkg-types';
 
 import {
@@ -42,6 +42,7 @@ import type {
   ConfigNames,
   OptionsCss,
   OptionsOverrides,
+  OptionsTailwind,
   OptionsTypeScriptWithTypes,
   OptionsWithDrizzle,
   OptionsWithFiles,
@@ -66,7 +67,7 @@ interface ESLint2DigitsOptions {
   graphql?: SharedOptions<OptionsWithFiles> | boolean;
   react?: SharedOptions<OptionsWithReact> | boolean;
   next?: SharedOptions<OptionsWithFiles> | boolean;
-  tailwind?: SharedOptions<OptionsOverrides> | boolean;
+  tailwind?: SharedOptions<OptionsTailwind> | boolean;
   storybook?: SharedOptions<OptionsWithStorybook> | boolean;
   vitest?: SharedOptions<OptionsWithVitest> | boolean;
   tanstackQuery?: SharedOptions<OptionsOverrides> | boolean;
@@ -92,6 +93,18 @@ export function extractConfig<T>(options: SharedOptions<T> | undefined | boolean
   const { enable: _, ...rest } = options;
 
   return rest as T;
+}
+
+function isTailwindV4Installed(): boolean {
+  if (!isPackageExists('tailwindcss')) {
+    return false;
+  }
+
+  const info = getPackageInfoSync('tailwindcss');
+  const [majorVersion = '0'] = info?.version?.split('.', 1) ?? [];
+  const major = Number.parseInt(majorVersion, 10);
+
+  return Number.isFinite(major) && major >= 4;
 }
 
 // eslint-disable-next-line sonar/cognitive-complexity
@@ -177,7 +190,7 @@ export async function twoDigits(
     composer = composer.append(vitest(extractConfig(options.vitest)));
   }
 
-  if (enabled(options.tailwind, isPackageExists('tailwindcss'))) {
+  if (enabled(options.tailwind, isTailwindV4Installed())) {
     composer = composer.append(tailwind(extractConfig(options.tailwind)));
   }
 

--- a/packages/eslint-config/src/stub.d.ts
+++ b/packages/eslint-config/src/stub.d.ts
@@ -22,17 +22,31 @@ declare module '@eslint-community/eslint-plugin-eslint-comments/configs' {
 }
 
 declare module 'eslint-plugin-tailwindcss' {
-  import type { ClassicConfig, Linter, FlatConfig } from '@typescript-eslint/utils/ts-eslint';
+  import type { FlatConfig, Linter } from '@typescript-eslint/utils/ts-eslint';
 
-  const exprt: {
+  type PluginSettings = {
+    attributes?: Array<string>;
+    cssConfigPath: string;
+    functions?: Array<string>;
+    parseKeyFunctions?: Array<string>;
+    ignoredKeys?: Array<string>;
+    cacheMaxSize?: number;
+    cacheMaxAge?: number;
+  };
+
+  const plugin: {
+    meta: {
+      name: string;
+      version: string;
+    };
     configs: {
-      recommended: ClassicConfig.Config;
-      'flat/recommended': FlatConfig.ConfigArray;
+      recommended: FlatConfig.Config;
     };
     rules: NonNullable<Linter.Plugin['rules']>;
   };
 
-  export = exprt;
+  export type { PluginSettings };
+  export default plugin;
 }
 
 declare module 'eslint-plugin-drizzle' {

--- a/packages/eslint-config/src/types.gen.d.ts
+++ b/packages/eslint-config/src/types.gen.d.ts
@@ -6356,43 +6356,43 @@ Backward pagination arguments
    */
   'symbol-description'?: Linter.RuleEntry<[]>
   /**
-   * Enforce a consistent and logical order of the Tailwind CSS classnames
-   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/tree/master/docs/rules/classnames-order.md
+   * Enforces a consistent order for the Tailwind CSS classnames, based on the compiler.
+   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/alpha/v4-basic-files/docs/rules/classnames-order.md
    */
   'tailwindcss/classnames-order'?: Linter.RuleEntry<TailwindcssClassnamesOrder>
   /**
-   * Warns about dash prefixed classnames using arbitrary values
-   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/tree/master/docs/rules/enforces-negative-arbitrary-values.md
+   * Warns about `-` prefixed classnames using arbitrary values.
+   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/alpha/v4-basic-files/docs/rules/enforces-negative-arbitrary-values.md
    */
   'tailwindcss/enforces-negative-arbitrary-values'?: Linter.RuleEntry<TailwindcssEnforcesNegativeArbitraryValues>
   /**
-   * Enforces the usage of shorthand Tailwind CSS classnames
-   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/tree/master/docs/rules/enforces-shorthand.md
+   * Avoid using multiple Tailwind CSS classnames when not required.
+   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/alpha/v4-basic-files/docs/rules/enforces-shorthand.md
    */
   'tailwindcss/enforces-shorthand'?: Linter.RuleEntry<TailwindcssEnforcesShorthand>
   /**
-   * Detect obsolete classnames when upgrading to Tailwind CSS v3
-   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/tree/master/docs/rules/migration-from-tailwind-2.md
+   * In v4 you should place the `!` at the very end of the class name.
+   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/alpha/v4-basic-files/docs/rules/important-modifier-suffix.md
    */
-  'tailwindcss/migration-from-tailwind-2'?: Linter.RuleEntry<TailwindcssMigrationFromTailwind2>
+  'tailwindcss/important-modifier-suffix'?: Linter.RuleEntry<TailwindcssImportantModifierSuffix>
   /**
-   * Forbid using arbitrary values in classnames
-   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/tree/master/docs/rules/no-arbitrary-value.md
+   * Forbid using arbitrary values in classnames.
+   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/alpha/v4-basic-files/docs/rules/no-arbitrary-value.md
    */
   'tailwindcss/no-arbitrary-value'?: Linter.RuleEntry<TailwindcssNoArbitraryValue>
   /**
-   * Avoid contradicting Tailwind CSS classnames (e.g. "w-3 w-5")
-   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/tree/master/docs/rules/no-contradicting-classname.md
+   * Avoid contradicting Tailwind CSS classnames.
+   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/alpha/v4-basic-files/docs/rules/no-contradicting-classname.md
    */
   'tailwindcss/no-contradicting-classname'?: Linter.RuleEntry<TailwindcssNoContradictingClassname>
   /**
-   * Detect classnames which do not belong to Tailwind CSS
-   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/tree/master/docs/rules/no-custom-classname.md
+   * Detects classnames which do not belong to Tailwind CSS.
+   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/alpha/v4-basic-files/docs/rules/no-custom-classname.md
    */
   'tailwindcss/no-custom-classname'?: Linter.RuleEntry<TailwindcssNoCustomClassname>
   /**
-   * Forbid using arbitrary values in classnames when an equivalent preset exists
-   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/tree/master/docs/rules/no-unnecessary-arbitrary-value.md
+   * Avoid unjustified arbitrary classnames.
+   * @see https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/alpha/v4-basic-files/docs/rules/no-unnecessary-arbitrary-value.md
    */
   'tailwindcss/no-unnecessary-arbitrary-value'?: Linter.RuleEntry<TailwindcssNoUnnecessaryArbitraryValue>
   /**
@@ -15082,89 +15082,24 @@ type SwitchColonSpacing = []|[{
   after?: boolean
 }]
 // ----- tailwindcss/classnames-order -----
-type TailwindcssClassnamesOrder = []|[{
-  callees?: string[]
-  ignoredKeys?: string[]
-  config?: (string | {
-    [k: string]: unknown | undefined
-  })
-  removeDuplicates?: boolean
-  tags?: string[]
-  [k: string]: unknown | undefined
-}]
+type TailwindcssClassnamesOrder = []|[{}]
 // ----- tailwindcss/enforces-negative-arbitrary-values -----
-type TailwindcssEnforcesNegativeArbitraryValues = []|[{
-  callees?: string[]
-  ignoredKeys?: string[]
-  config?: (string | {
-    [k: string]: unknown | undefined
-  })
-  tags?: string[]
-  [k: string]: unknown | undefined
-}]
+type TailwindcssEnforcesNegativeArbitraryValues = []|[{}]
 // ----- tailwindcss/enforces-shorthand -----
-type TailwindcssEnforcesShorthand = []|[{
-  callees?: string[]
-  ignoredKeys?: string[]
-  config?: (string | {
-    [k: string]: unknown | undefined
-  })
-  tags?: string[]
-  [k: string]: unknown | undefined
-}]
-// ----- tailwindcss/migration-from-tailwind-2 -----
-type TailwindcssMigrationFromTailwind2 = []|[{
-  callees?: string[]
-  ignoredKeys?: string[]
-  config?: (string | {
-    [k: string]: unknown | undefined
-  })
-  tags?: string[]
-  [k: string]: unknown | undefined
-}]
+type TailwindcssEnforcesShorthand = []|[{}]
+// ----- tailwindcss/important-modifier-suffix -----
+type TailwindcssImportantModifierSuffix = []|[{}]
 // ----- tailwindcss/no-arbitrary-value -----
-type TailwindcssNoArbitraryValue = []|[{
-  callees?: string[]
-  ignoredKeys?: string[]
-  config?: (string | {
-    [k: string]: unknown | undefined
-  })
-  tags?: string[]
-  [k: string]: unknown | undefined
-}]
+type TailwindcssNoArbitraryValue = []|[{}]
 // ----- tailwindcss/no-contradicting-classname -----
-type TailwindcssNoContradictingClassname = []|[{
-  callees?: string[]
-  ignoredKeys?: string[]
-  config?: (string | {
-    [k: string]: unknown | undefined
-  })
-  tags?: string[]
-  [k: string]: unknown | undefined
-}]
+type TailwindcssNoContradictingClassname = []|[{}]
 // ----- tailwindcss/no-custom-classname -----
 type TailwindcssNoCustomClassname = []|[{
-  callees?: string[]
-  ignoredKeys?: string[]
-  config?: (string | {
-    [k: string]: unknown | undefined
-  })
-  cssFiles?: string[]
-  cssFilesRefreshRate?: number
-  tags?: string[]
+  
   whitelist?: string[]
-  [k: string]: unknown | undefined
 }]
 // ----- tailwindcss/no-unnecessary-arbitrary-value -----
-type TailwindcssNoUnnecessaryArbitraryValue = []|[{
-  callees?: string[]
-  ignoredKeys?: string[]
-  config?: (string | {
-    [k: string]: unknown | undefined
-  })
-  tags?: string[]
-  [k: string]: unknown | undefined
-}]
+type TailwindcssNoUnnecessaryArbitraryValue = []|[{}]
 // ----- tanstack-query/exhaustive-deps -----
 type TanstackQueryExhaustiveDeps = []|[{
   allowlist?: {

--- a/packages/eslint-config/src/types.ts
+++ b/packages/eslint-config/src/types.ts
@@ -119,3 +119,12 @@ export interface OptionsCss extends OptionsOverrides {
    */
   customSyntax?: unknown;
 }
+
+export interface OptionsTailwind extends OptionsOverrides {
+  /**
+   * Path to the main Tailwind CSS v4 entry CSS file. Required by eslint-plugin-tailwindcss v4 for theme-aware rules.
+   *
+   * When omitted, searches for common CSS entry files such as `src/globals.css`, `app/globals.css`, and `styles.css`.
+   */
+  cssConfigPath?: string;
+}

--- a/packages/eslint-config/test/__snapshots__/factory/full.snap.json
+++ b/packages/eslint-config/test/__snapshots__/factory/full.snap.json
@@ -1872,7 +1872,7 @@
     ],
     "settings": {
       "tailwindcss": {
-        "callees": [
+        "functions": [
           "tv",
           "cn",
           "cnBase",
@@ -1886,7 +1886,7 @@
       "tailwindcss/classnames-order",
       "tailwindcss/enforces-negative-arbitrary-values",
       "tailwindcss/enforces-shorthand",
-      "tailwindcss/migration-from-tailwind-2",
+      "tailwindcss/important-modifier-suffix",
       "- tailwindcss/no-arbitrary-value",
       "tailwindcss/no-contradicting-classname",
       "tailwindcss/no-custom-classname",

--- a/packages/eslint-config/test/__snapshots__/factory/next-stack.snap.json
+++ b/packages/eslint-config/test/__snapshots__/factory/next-stack.snap.json
@@ -1770,7 +1770,7 @@
     ],
     "settings": {
       "tailwindcss": {
-        "callees": [
+        "functions": [
           "tv",
           "cn",
           "cnBase",
@@ -1784,7 +1784,7 @@
       "tailwindcss/classnames-order",
       "tailwindcss/enforces-negative-arbitrary-values",
       "tailwindcss/enforces-shorthand",
-      "tailwindcss/migration-from-tailwind-2",
+      "tailwindcss/important-modifier-suffix",
       "- tailwindcss/no-arbitrary-value",
       "tailwindcss/no-contradicting-classname",
       "tailwindcss/no-custom-classname",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,8 +178,8 @@ catalogs:
       specifier: 10.5.3
       version: 10.5.3
     eslint-plugin-tailwindcss:
-      specifier: 3.18.2
-      version: 3.18.2
+      specifier: 4.2.0
+      version: 4.2.0
     eslint-plugin-toml:
       specifier: 1.4.0
       version: 1.4.0
@@ -261,6 +261,9 @@ catalogs:
     tailwind-csstree:
       specifier: 0.3.3
       version: 0.3.3
+    tailwindcss:
+      specifier: 4.3.3
+      version: 4.3.3
     tegami:
       specifier: 1.2.6
       version: 1.2.6
@@ -555,7 +558,7 @@ importers:
         version: 10.5.3(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.2.5(@arethetypeswrong/core@0.18.5)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@voidzero-dev/vite-plus-core@0.2.5(@arethetypeswrong/core@0.18.5)(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)))(supports-color@7.2.0)(typescript@6.0.3)
       eslint-plugin-tailwindcss:
         specifier: 'catalog:'
-        version: 3.18.2(tailwindcss@3.4.17)
+        version: 4.2.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(tailwindcss@4.3.3)(typescript@6.0.3)
       eslint-plugin-toml:
         specifier: 'catalog:'
         version: 1.4.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
@@ -629,6 +632,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.8
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.3.3
       tinyexec:
         specifier: 'catalog:'
         version: 1.2.4
@@ -953,10 +959,6 @@ packages:
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
-
-  '@alloc/quick-lru@5.2.0':
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1985,10 +1987,6 @@ packages:
 
   '@nolyfill/globalthis@1.0.44':
     resolution: {integrity: sha512-PXEAAubKN6zy9AVSrjzYdEaOaPdoFTMxuiDyc2BYGgrvFQ+NiqZD4Q4JHuR9tPKQyZifQ3MnG8SA/8f21+FIrQ==}
-    engines: {node: '>=12.4.0'}
-
-  '@nolyfill/is-core-module@1.0.39':
-    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
   '@nolyfill/safe-buffer@1.0.44':
@@ -4257,19 +4255,9 @@ packages:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
-  any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
-
-  arg@5.0.2:
-    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -4333,10 +4321,6 @@ packages:
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
 
   binary-searching@2.0.5:
     resolution: {integrity: sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==}
@@ -4435,10 +4419,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
-
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -4476,10 +4456,6 @@ packages:
 
   chevrotain@7.1.1:
     resolution: {integrity: sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==}
-
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -4531,10 +4507,6 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
-
-  commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
 
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -4741,9 +4713,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4759,9 +4728,6 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
-
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -5040,11 +5006,16 @@ packages:
       eslint: '>=8'
       storybook: ^10.5.3
 
-  eslint-plugin-tailwindcss@3.18.2:
-    resolution: {integrity: sha512-QbkMLDC/OkkjFQ1iz/5jkMdHfiMu/uwujUHLAJK5iwNHD8RTxVTlsUezE0toTZ6VhybNBsk+gYGPDq2agfeRNA==}
-    engines: {node: '>=18.12.0'}
+  eslint-plugin-tailwindcss@4.2.0:
+    resolution: {integrity: sha512-TSygSjEL54Iks7K29FjvM9Lp03cpsYtbh3LJHnj/84FxCOYfLFuvQ+GioHOxgq19WGN5NbHPuvFDz/igIOEtbg==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      tailwindcss: ^3.4.0
+      eslint: ^9.0.0 || ^10.0.0
+      tailwindcss: ^4.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   eslint-plugin-toml@1.4.0:
     resolution: {integrity: sha512-3ErTnfUjXq/23f72XeyRcE0Y4Sd/ME1lsZeezczqpn2R4tE7+Sgco/NUKDXm0xAMz15tzcRz/9RfJRm6AqRO+A==}
@@ -5580,10 +5551,6 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
   is-builtin-module@5.0.0:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
     engines: {node: '>=18.20'}
@@ -5660,10 +5627,6 @@ packages:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
-
-  jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
-    hasBin: true
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -5863,10 +5826,6 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
-
-  lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -6216,9 +6175,6 @@ packages:
     resolution: {integrity: sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==}
     engines: {node: '>=0.8.0'}
 
-  mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-
   nan@2.27.0:
     resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
@@ -6313,16 +6269,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   object-deep-merge@2.0.1:
     resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
-
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -6557,9 +6505,6 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
-  path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -6590,14 +6535,6 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-
-  pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
-
   pkg-pr-new@0.0.79:
     resolution: {integrity: sha512-ip74NzaakGZha5s/X1T7j+Ez9/bRNDhzxQZTfnzAzoI7zO9JnMRdoiIfCLyy+ZzxxXg8WXRW2WcdvdORI0O30w==}
     hasBin: true
@@ -6619,46 +6556,15 @@ packages:
   pnpm-workspace-yaml@1.7.0:
     resolution: {integrity: sha512-cgjaozHkjWL4H8oKZydEWE4mg31XydK3/1cLKjHvwnFAXutp45yAlMKljpOdZEq4TtLuzYAMvy9j05wRm3aoPw==}
 
-  postcss-import@15.1.0:
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-js@4.1.0:
-    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-
-  postcss-nested@6.2.0:
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
-    engines: {node: '>=12.0'}
+  postcss-nested@7.0.2:
+    resolution: {integrity: sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==}
+    engines: {node: '>=18.0'}
     peerDependencies:
       postcss: ^8.2.14
 
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+  postcss-selector-parser@7.1.4:
+    resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
-
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
@@ -6821,16 +6727,9 @@ packages:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
-  read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-
   read-yaml-file@2.1.0:
     resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
     engines: {node: '>=10.13'}
-
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -6911,11 +6810,6 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
 
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
@@ -7132,11 +7026,6 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
-  sucrase@3.35.1:
-    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
-
   super-regex@1.1.0:
     resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
     engines: {node: '>=18'}
@@ -7144,10 +7033,6 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
 
   sync-fetch@0.6.0:
     resolution: {integrity: sha512-IELLEvzHuCfc1uTsshPK58ViSdNqXxlml1U+fmwJIKLYKOr/rAtBrorE2RYm5IHaMpDNlmC0fr1LAvdXvyheEQ==}
@@ -7161,6 +7046,11 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
+  tailwind-api-utils@1.0.3:
+    resolution: {integrity: sha512-KpzUHkH1ug1sq4394SLJX38ZtpeTiqQ1RVyFTTSY2XuHsNSTWUkRo108KmyyrMWdDbQrLYkSHaNKj/a3bmA4sQ==}
+    peerDependencies:
+      tailwindcss: ^3.3.0 || ^4.0.0 || ^4.0.0-beta
+
   tailwind-csstree@0.3.3:
     resolution: {integrity: sha512-je9J5UYRsTJqAjYrIBMMlge8T/rreRd44pJxgG5Zx/zeo4kAC/liUKqzztRZrGlYRJLvIf2Cb1DVJMTXSzEShA==}
     engines: {node: '>=18.18'}
@@ -7170,10 +7060,8 @@ packages:
       '@eslint/css':
         optional: true
 
-  tailwindcss@3.4.17:
-    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
   tapable@2.2.3:
     resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
@@ -7185,13 +7073,6 @@ packages:
 
   tegami@1.2.6:
     resolution: {integrity: sha512-gYwPJrEwb/C3TJVV5CZjg3L556hdkfQTxsH3Vj7byNv3wSZ5e5Y9pY9AW797wCe7e547FotvbgbnGUvqxQYT3Q==}
-
-  thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-
-  thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
@@ -7272,9 +7153,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
@@ -7667,8 +7545,6 @@ snapshots:
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
-
-  '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -9063,8 +8939,6 @@ snapshots:
   '@nolyfill/globalthis@1.0.44':
     dependencies:
       '@nolyfill/shared': 1.0.44
-
-  '@nolyfill/is-core-module@1.0.39': {}
 
   '@nolyfill/safe-buffer@1.0.44': {}
 
@@ -10784,16 +10658,7 @@ snapshots:
 
   ansis@4.3.1: {}
 
-  any-promise@1.3.0: {}
-
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.2
-
   are-docs-informative@0.0.2: {}
-
-  arg@5.0.2: {}
 
   argparse@1.0.10:
     dependencies:
@@ -10842,8 +10707,6 @@ snapshots:
   baseline-browser-mapping@2.11.0: {}
 
   bignumber.js@9.3.1: {}
-
-  binary-extensions@2.3.0: {}
 
   binary-searching@2.0.5: {}
 
@@ -10947,8 +10810,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-css@2.0.1: {}
-
   camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001799: {}
@@ -10981,18 +10842,6 @@ snapshots:
   chevrotain@7.1.1:
     dependencies:
       regexp-to-ast: 0.5.0
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   chokidar@5.0.0:
     dependencies:
@@ -11029,8 +10878,6 @@ snapshots:
   color-name@1.1.4: {}
 
   commander@14.0.3: {}
-
-  commander@4.1.1: {}
 
   commander@8.3.0: {}
 
@@ -11198,8 +11045,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  didyoumean@1.2.2: {}
-
   diff-sequences@29.6.3: {}
 
   diff@5.2.2: {}
@@ -11209,8 +11054,6 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  dlv@1.1.3: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -11613,11 +11456,19 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-tailwindcss@3.18.2(tailwindcss@3.4.17):
+  eslint-plugin-tailwindcss@4.2.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(tailwindcss@4.3.3)(typescript@6.0.3):
     dependencies:
-      fast-glob: 3.3.3
-      postcss: 8.5.15
-      tailwindcss: 3.4.17
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      eslint: 10.7.0(jiti@2.7.0)(supports-color@7.2.0)
+      postcss: 8.5.16
+      postcss-nested: 7.0.2(postcss@8.5.16)
+      synckit: 0.11.12
+      tailwind-api-utils: 1.0.3(tailwindcss@4.3.3)
+      tailwindcss: 4.3.3
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-toml@1.4.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
@@ -12242,10 +12093,6 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
   is-builtin-module@5.0.0:
     dependencies:
       builtin-modules: 5.0.0
@@ -12301,8 +12148,6 @@ snapshots:
   isows@1.0.7(ws@8.21.0):
     dependencies:
       ws: 8.21.0
-
-  jiti@1.21.7: {}
 
   jiti@2.7.0: {}
 
@@ -12476,8 +12321,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
-
-  lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
 
@@ -13009,12 +12852,6 @@ snapshots:
       rimraf: 2.4.5
     optional: true
 
-  mz@2.7.0:
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
-
   nan@2.27.0:
     optional: true
 
@@ -13103,11 +12940,7 @@ snapshots:
       pathe: 2.0.3
       tinyexec: 1.2.4
 
-  object-assign@4.1.1: {}
-
   object-deep-merge@2.0.1: {}
-
-  object-hash@3.0.0: {}
 
   obug@2.1.1: {}
 
@@ -13462,8 +13295,6 @@ snapshots:
 
   path-key@4.0.0: {}
 
-  path-parse@1.0.7: {}
-
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.5.2
@@ -13482,10 +13313,6 @@ snapshots:
   picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
-
-  pify@2.3.0: {}
-
-  pirates@4.0.7: {}
 
   pkg-pr-new@0.0.79: {}
 
@@ -13509,42 +13336,15 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  postcss-import@15.1.0(postcss@8.5.16):
+  postcss-nested@7.0.2(postcss@8.5.16):
     dependencies:
       postcss: 8.5.16
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.11
+      postcss-selector-parser: 7.1.4
 
-  postcss-js@4.1.0(postcss@8.5.16):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.16
-
-  postcss-load-config@4.0.2(postcss@8.5.16):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.9.0
-    optionalDependencies:
-      postcss: 8.5.16
-
-  postcss-nested@6.2.0(postcss@8.5.16):
-    dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 6.1.2
-
-  postcss-selector-parser@6.1.2:
+  postcss-selector-parser@7.1.4:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss-value-parser@4.2.0: {}
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.16:
     dependencies:
@@ -13646,18 +13446,10 @@ snapshots:
 
   react@19.2.8: {}
 
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
-
   read-yaml-file@2.1.0:
     dependencies:
       js-yaml: 4.1.1
       strip-bom: 4.0.0
-
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.2
 
   readdirp@5.0.0: {}
 
@@ -13888,12 +13680,6 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  resolve@1.22.11:
-    dependencies:
-      is-core-module: '@nolyfill/is-core-module@1.0.39'
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
   responselike@2.0.1:
     dependencies:
       lowercase-keys: 2.0.0
@@ -14089,16 +13875,6 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  sucrase@3.35.1:
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      commander: 4.1.1
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.7
-      tinyglobby: 0.2.17
-      ts-interface-checker: 0.1.13
-
   super-regex@1.1.0:
     dependencies:
       function-timeout: 1.0.2
@@ -14108,8 +13884,6 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  supports-preserve-symlinks-flag@1.0.0: {}
 
   sync-fetch@0.6.0:
     dependencies:
@@ -14123,36 +13897,18 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tailwind-api-utils@1.0.3(tailwindcss@4.3.3):
+    dependencies:
+      enhanced-resolve: 5.18.3
+      jiti: 2.7.0
+      local-pkg: 1.2.1
+      tailwindcss: 4.3.3
+
   tailwind-csstree@0.3.3(@eslint/css@1.4.0):
     optionalDependencies:
       '@eslint/css': 1.4.0
 
-  tailwindcss@3.4.17:
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.16
-      postcss-import: 15.1.0(postcss@8.5.16)
-      postcss-js: 4.1.0(postcss@8.5.16)
-      postcss-load-config: 4.0.2(postcss@8.5.16)
-      postcss-nested: 6.2.0(postcss@8.5.16)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.11
-      sucrase: 3.35.1
-    transitivePeerDependencies:
-      - ts-node
+  tailwindcss@4.3.3: {}
 
   tapable@2.2.3: {}
 
@@ -14172,14 +13928,6 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       yaml: 2.9.0
-
-  thenify-all@1.6.0:
-    dependencies:
-      thenify: 3.3.1
-
-  thenify@3.3.1:
-    dependencies:
-      any-promise: 1.3.0
 
   time-span@5.1.0:
     dependencies:
@@ -14238,8 +13986,6 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
-
-  ts-interface-checker@0.1.13: {}
 
   ts-pattern@5.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,7 @@ catalog:
   eslint-plugin-regexp: 3.1.1
   eslint-plugin-sonarjs: 4.2.0
   eslint-plugin-storybook: 10.5.3
-  eslint-plugin-tailwindcss: 3.18.2
+  eslint-plugin-tailwindcss: 4.2.0
   eslint-plugin-toml: 1.4.0
   eslint-plugin-turbo: 2.10.5
   eslint-plugin-unicorn: 72.0.0
@@ -97,6 +97,7 @@ catalog:
   react: 19.2.8
   renovate: 43.275.2
   tailwind-csstree: 0.3.3
+  tailwindcss: 4.3.3
   tinyexec: 1.2.4
   tinyglobby: 0.2.17
   ts-api-utils: 2.5.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades `eslint-plugin-tailwindcss` from `3.18.2` to `4.2.0`, which is rewritten for Tailwind CSS v4.

### Changes
- Catalog bump to `eslint-plugin-tailwindcss@4.2.0` and add `tailwindcss@4.3.3`
- Update Tailwind ESLint config for the v4 plugin API:
  - `callees` → `functions`
  - `config` (JS) → `cssConfigPath` (CSS entry), with common-path discovery and an explicit `cssConfigPath` option
- Auto-enable the Tailwind ESLint preset only when Tailwind CSS v4+ is installed
- Add optional `tailwindcss` peer dependency
- Drop removed `migration-from-tailwind-2` rule; pick up new `important-modifier-suffix`
- Regenerate rule types and factory snapshots
- Migrate fixture CSS to `@import 'tailwindcss'`

### Validation
- `vp test` in `@2digits/eslint-config` (23 tests)
- Smoke lint against a Tailwind v4 CSS entry confirmed theme-aware rules (e.g. `classnames-order`) run successfully

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6035031b-4c71-4874-b533-6d159cc1d465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6035031b-4c71-4874-b533-6d159cc1d465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

